### PR TITLE
添加docker部署web方式

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN mkdir -p /app/data /app/logs
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN echo 'deb http://mirrors.aliyun.com/debian/ bookworm main' > /etc/apt/sources.list && \
+    echo 'deb-src http://mirrors.aliyun.com/debian/ bookworm main' >> /etc/apt/sources.list && \
+    echo 'deb http://mirrors.aliyun.com/debian/ bookworm-updates main' >> /etc/apt/sources.list && \
+    echo 'deb-src http://mirrors.aliyun.com/debian/ bookworm-updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://mirrors.aliyun.com/debian-security bookworm-security main' >> /etc/apt/sources.list && \
+    echo 'deb-src http://mirrors.aliyun.com/debian-security bookworm-security main' >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+COPY requirements_db.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple && \
+    pip install --no-cache-dir pytdx -i https://mirrors.aliyun.com/pypi/simple && \
+    pip install --no-cache-dir -r requirements_db.txt -i https://mirrors.aliyun.com/pypi/simple
+
+COPY . .
+
+EXPOSE 8501
+
+CMD ["python", "-m", "streamlit", "run", "web/app.py", "--server.address=0.0.0.0", "--server.port=8501"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,25 @@
 version: '3.8'
 
 services:
-  # MongoDB数据库服务
+  # Streamlit Web 应用服务
+  web:
+    build: .
+    container_name: TradingAgents-web
+    ports:
+      - "8501:8501"
+    volumes:
+      - .env:/app/.env
+    environment:
+      PYTHONUNBUFFERED: 1
+      PYTHONDONTWRITEBYTECODE: 1
+    command: python -m streamlit run web/app.py --server.address=0.0.0.0 --server.port=8501
+    depends_on:
+      - redis
+    networks:
+      - tradingagents-network
+
+
+  # MongoDB 数据库服务
   mongodb:
     image: mongo:4.4
     container_name: tradingagents-mongodb
@@ -24,7 +42,7 @@ services:
       retries: 3
       start_period: 40s
 
-  # Redis缓存服务
+  # Redis 缓存服务
   redis:
     image: redis:latest
     container_name: tradingagents-redis
@@ -37,13 +55,13 @@ services:
     networks:
       - tradingagents-network
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      test: ["CMD", "redis-cli", "-a", "tradingagents123", "ping"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
-  # Redis Commander管理界面
+  # Redis 可视化管理界面
   redis-commander:
     image: rediscommander/redis-commander:latest
     container_name: tradingagents-redis-commander
@@ -63,7 +81,7 @@ services:
       retries: 3
       start_period: 30s
 
-  # Mongo Express管理界面 (可选)
+  # Mongo Express 可视化管理界面（可选）
   mongo-express:
     image: mongo-express:latest
     container_name: tradingagents-mongo-express
@@ -81,7 +99,7 @@ services:
     depends_on:
       - mongodb
     profiles:
-      - management  # 使用 --profile management 启动
+      - management
 
 # 数据卷定义
 volumes:

--- a/requirements_db.txt
+++ b/requirements_db.txt
@@ -10,6 +10,3 @@ hiredis>=2.2.0  # Redis性能优化（可选）
 # 数据处理
 pandas>=2.0.0
 numpy>=1.24.0
-
-# 序列化
-pickle5>=0.0.11  # Python 3.8+兼容


### PR DESCRIPTION
使用方法:
1.将.env.examle文件重命名为.env,并配置好相关KEY
2.docker-compose up -d启动即可

Bug:
1.容器与宿主机文件夹链接需优化
2.MongoDB与Redis配置未优化
3.MongoDB与Redis部署流程需简化步骤目前过于繁琐+

目前因为有些bug，pr到main分支不知道是否正确，可能pr到develop会好些，请审核