### PR TITLE
为文件操作添加UTF-8编码支持

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1037,7 +1037,7 @@ def run_analysis():
             func(*args, **kwargs)
             timestamp, message_type, content = obj.messages[-1]
             content = content.replace("\n", " ")  # Replace newlines with spaces
-            with open(log_file, "a") as f:
+            with open(log_file, "a", encoding="utf-8") as f:
                 f.write(f"{timestamp} [{message_type}] {content}\n")
         return wrapper
     
@@ -1048,7 +1048,7 @@ def run_analysis():
             func(*args, **kwargs)
             timestamp, tool_name, args = obj.tool_calls[-1]
             args_str = ", ".join(f"{k}={v}" for k, v in args.items())
-            with open(log_file, "a") as f:
+            with open(log_file, "a", encoding="utf-8") as f:
                 f.write(f"{timestamp} [Tool Call] {tool_name}({args_str})\n")
         return wrapper
 
@@ -1061,7 +1061,7 @@ def run_analysis():
                 content = obj.report_sections[section_name]
                 if content:
                     file_name = f"{section_name}.md"
-                    with open(report_dir / file_name, "w") as f:
+                    with open(report_dir / file_name, "w", encoding="utf-8") as f:
                         f.write(content)
         return wrapper
 
@@ -1648,7 +1648,7 @@ def version():
     """
     # 读取版本号
     try:
-        with open("VERSION", "r") as f:
+        with open("VERSION", "r", encoding="utf-8") as f:
             version = f.read().strip()
     except FileNotFoundError:
         version = "1.0.0"


### PR DESCRIPTION
- 在所有文件操作中显式指定UTF-8编码
- 确保日志文件和版本文件能正确处理非ASCII字符
- 提高代码在不同环境下的兼容性

修复了可能因编码问题导致的文件读写异常