### PR TITLE
fix: 修复Docker安装pip超时问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,17 @@ RUN echo '#!/bin/bash\nXvfb :99 -screen 0 1024x768x24 -ac +extension GLX &\nexpo
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
+#多源轮询安装依赖
+RUN set -e; \
+    for src in \
+        https://mirrors.aliyun.com/pypi/simple \
+        https://pypi.tuna.tsinghua.edu.cn/simple \
+        https://pypi.doubanio.com/simple \
+        https://pypi.org/simple; do \
+      echo "Try installing from $src"; \
+      pip install --no-cache-dir -r requirements.txt -i $src && break; \
+      echo "Failed at $src, try next"; \
+    done
 
 # 复制日志配置文件
 COPY config/ ./config/


### PR DESCRIPTION
- 添加多源轮询策略
- 添加阿里云、清华、豆瓣、官方 PyPI源

在使用过程中有时阿里云安装依赖会超时导致报错，添加多源以解决此问题
<img width="1458" height="384" alt="image" src="https://github.com/user-attachments/assets/7839ebff-6627-4af1-b8e5-bf8172bbe05b" />
