### PR TITLE
修复了logging_manager.py中函数 _load_config_file使用了未定义的变量 logger造成的NameError导致的崩溃

### DIFF
--- a/tradingagents/utils/logging_manager.py
+++ b/tradingagents/utils/logging_manager.py
@@ -15,8 +15,8 @@ import json
 import toml
 
 # 注意：这里不能导入自己，会造成循环导入
-# logger将在类定义后创建
-
+# 在日志系统初始化前，使用标准库自举日志器，避免未定义引用
+_bootstrap_logger = logging.getLogger("tradingagents.logging_manager")
 
 
 class ColoredFormatter(logging.Formatter):
@@ -146,7 +146,7 @@ class TradingAgentsLogger:
                     # 转换配置格式
                     return self._convert_toml_config(config_data)
                 except Exception as e:
-                    logger.warning(f"警告: 无法加载配置文件 {config_path}: {e}")
+                    _bootstrap_logger.warning(f"警告: 无法加载配置文件 {config_path}: {e}")
                     continue
 
         return None


### PR DESCRIPTION
在 tradingagents/utils/logging_manager.py 中存在一个会导致运行时崩溃的明显缺陷：函数 _load_config_file 的异常处理分支里使用了未定义的变量 logger，从而触发 NameError。该问题一旦出现（例如 logging.toml 配置文件不存在或格式错误），日志系统初始化会直接失败，进而影响主要实现逻辑（CLI/Web/核心图引擎）的启动与运行。

---

具体修改：
1.在文件顶部定义模块级自举日志器，确保初始化早期可安全记录告警
2.将异常分支使用的未定义 logger 替换为自举日志器
