### PR TITLE
feat: 添加历史记录功能和结果保存机制

### DIFF
--- a/web/components/sidebar.py
+++ b/web/components/sidebar.py
@@ -812,7 +812,7 @@ def render_sidebar():
                     st.session_state.custom_model = ""
 
                 # 自定义模型输入 - 使用session state作为默认值
-                default_value = st.session_state.custom_model if st.session_state.custom_model else "anthropic/claude-3.7-sonnet"
+                default_value = st.session_state.custom_model if st.session_state.custom_model else "openrouter/sonoma-sky-alpha"
 
                 llm_model = st.text_input(
                     "输入模型ID",

--- a/web/modules/history_page.py
+++ b/web/modules/history_page.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Streamlit history page for browsing past analyses and viewing details.
+"""
+
+import streamlit as st
+from typing import Optional
+
+from tradingagents.utils.logging_manager import get_logger
+from utils.history_manager import list_history, get_history_item
+from utils.analysis_runner import format_analysis_results
+from components.results_display import render_results
+
+logger = get_logger('history_page')
+
+
+def render_history_page():
+    st.header("📈 历史记录")
+
+    # Filters
+    with st.expander("筛选条件", expanded=True):
+        col1, col2, col3 = st.columns([2, 1, 1])
+        with col1:
+            symbol = st.text_input("股票代码 (可选)", value="", placeholder="如 AAPL / 600519 / 00700")
+        with col2:
+            limit = st.number_input("显示条目数", min_value=10, max_value=500, value=50, step=10)
+        with col3:
+            refresh = st.button("🔄 刷新")
+
+    if refresh:
+        st.rerun()
+
+    symbol_filter = symbol.strip() or None
+
+    entries = list_history(limit=int(limit), symbol=symbol_filter)
+    if not entries:
+        st.info("暂无历史记录")
+        return
+
+    # List view
+    st.subheader("最近分析")
+    st.caption(f"共 {len(entries)} 条记录")
+    for entry in entries:
+        with st.container():
+            top = st.columns([2, 2, 2, 2, 2, 2])
+            with top[0]:
+                st.write(f"**{entry.get('stock_symbol','')}**")
+                st.caption(entry.get('analysis_id',''))
+            with top[1]:
+                st.write(f"日期: {entry.get('analysis_date','')}" )
+                st.write(f"时间: {entry.get('created_at','')}")
+            with top[2]:
+                st.write(f"状态: {'✅ 成功' if entry.get('success') else '❌ 失败'}")
+            with top[3]:
+                action = entry.get('action') or '-'
+                st.write(f"建议: {action}")
+            with top[4]:
+                tp = entry.get('target_price')
+                st.write(f"目标价: {tp if tp is not None else '-'}")
+            with top[5]:
+                if st.button("查看报告", key=f"view_{entry.get('analysis_id')}"):
+                    st.session_state['history_view_id'] = entry.get('analysis_id')
+
+    # Detail view
+    view_id: Optional[str] = st.session_state.get('history_view_id')
+    if not view_id and entries:
+        # Auto select newest entry for first load
+        st.session_state['history_view_id'] = entries[0].get('analysis_id')
+        view_id = st.session_state['history_view_id']
+    if view_id:
+        st.markdown("---")
+        st.subheader("历史分析报告")
+        data = get_history_item(view_id)
+        if not data:
+            st.warning("未找到该历史记录")
+            return
+        try:
+            formatted = format_analysis_results(data)
+            if formatted and formatted.get('success', False):
+                render_results(formatted)
+            else:
+                st.error("该记录无效或未成功")
+        except Exception as e:
+            logger.error(f"Failed to render history item {view_id}: {e}")
+            st.error("渲染历史报告失败")
+
+

--- a/web/utils/history_manager.py
+++ b/web/utils/history_manager.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Analysis history manager
+
+Persists each analysis result as a JSON file and maintains an index for quick listing.
+
+Storage layout:
+- data/history/index.json: list of entries metadata
+- data/history/{analysis_id}.json: full raw results
+"""
+
+import json
+import os
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tradingagents.utils.logging_manager import get_logger
+from .async_progress_tracker import safe_serialize
+
+logger = get_logger('history')
+
+
+HISTORY_DIR = Path("data/history")
+INDEX_FILE = HISTORY_DIR / "index.json"
+
+
+def _ensure_dirs() -> None:
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _load_index() -> List[Dict[str, Any]]:
+    _ensure_dirs()
+    if INDEX_FILE.exists():
+        try:
+            with INDEX_FILE.open('r', encoding='utf-8') as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    return data
+        except Exception as e:
+            logger.warning(f"Failed to load history index: {e}")
+    return []
+
+
+def _save_index(index: List[Dict[str, Any]]) -> None:
+    _ensure_dirs()
+    try:
+        with INDEX_FILE.open('w', encoding='utf-8') as f:
+            json.dump(index, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logger.error(f"Failed to save history index: {e}")
+
+
+def _build_entry_from_results(analysis_id: str, results: Dict[str, Any]) -> Dict[str, Any]:
+    # Extract minimal metadata for fast listing
+    stock_symbol = results.get('stock_symbol') or results.get('ticker') or 'UNKNOWN'
+    analysis_date = results.get('analysis_date') or results.get('date') or ''
+    success = bool(results.get('success', True))
+    decision = results.get('decision', {}) or {}
+    action = None
+    target_price = None
+    confidence = None
+    risk_score = None
+
+    if isinstance(decision, dict):
+        action = decision.get('action')
+        target_price = decision.get('target_price')
+        confidence = decision.get('confidence')
+        risk_score = decision.get('risk_score')
+    elif isinstance(decision, str):
+        action = decision
+
+    created_at = datetime.utcnow().isoformat() + 'Z'
+
+    return {
+        'analysis_id': analysis_id,
+        'stock_symbol': stock_symbol,
+        'analysis_date': analysis_date,
+        'success': success,
+        'action': action,
+        'target_price': target_price,
+        'confidence': confidence,
+        'risk_score': risk_score,
+        'created_at': created_at,
+    }
+
+
+def save_analysis_result(analysis_id: str, results: Dict[str, Any]) -> Optional[str]:
+    """
+    Persist the given analysis results and update index.
+
+    Returns path to saved result file, or None on failure.
+    """
+    try:
+        _ensure_dirs()
+
+        # Save full results with safe serialization
+        result_path = HISTORY_DIR / f"{analysis_id}.json"
+        with result_path.open('w', encoding='utf-8') as f:
+            # Use safe_serialize to handle LangChain messages and other non-serializable objects
+            safe_results = safe_serialize(results)
+            json.dump(safe_results, f, ensure_ascii=False, indent=2)
+
+        # Update index (prepend newest). If index is missing/corrupt, rebuild from files.
+        index = _load_index()
+        entry = _build_entry_from_results(analysis_id, results)
+        try:
+            # Remove existing entry with same id if present
+            index = [e for e in index if e.get('analysis_id') != analysis_id]
+            index.insert(0, entry)
+        except Exception:
+            # Rebuild: scan history files
+            index = _rebuild_index()
+            index = [e for e in index if e.get('analysis_id') != analysis_id]
+            index.insert(0, entry)
+        # Cap index length to prevent unbounded growth
+        if len(index) > 5000:
+            index = index[:5000]
+        _save_index(index)
+
+        logger.info(f"Saved analysis result to {result_path}")
+        return str(result_path)
+    except Exception as e:
+        logger.error(f"Failed to save analysis result: {e}")
+        return None
+
+
+def list_history(limit: int = 200, symbol: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Return recent history entries, optionally filtered by symbol. Auto-rebuild if index is empty but files exist."""
+    index = _load_index()
+    if not index:
+        # Attempt rebuild when empty index but there may be files
+        index = _rebuild_index()
+    if symbol:
+        index = [e for e in index if str(e.get('stock_symbol', '')).upper() == str(symbol).upper()]
+    return index[:limit]
+
+
+def get_history_item(analysis_id: str) -> Optional[Dict[str, Any]]:
+    """Load a full saved result by id."""
+    result_path = HISTORY_DIR / f"{analysis_id}.json"
+    if not result_path.exists():
+        return None
+    try:
+        with result_path.open('r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"Failed to read history item {analysis_id}: {e}")
+        return None
+
+
+def _rebuild_index() -> List[Dict[str, Any]]:
+    """Rebuild index from existing history files."""
+    _ensure_dirs()
+    entries: List[Dict[str, Any]] = []
+    try:
+        for file in HISTORY_DIR.glob("*.json"):
+            try:
+                with file.open('r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    analysis_id = file.stem
+                    entries.append(_build_entry_from_results(analysis_id, data))
+            except Exception:
+                continue
+        # Sort by created_at desc if present
+        entries.sort(key=lambda e: e.get('created_at', ''), reverse=True)
+        _save_index(entries)
+    except Exception as e:
+        logger.warning(f"Failed to rebuild history index: {e}")
+    return entries
+
+


### PR DESCRIPTION
- 在app.py中集成历史记录页面，允许用户查看过去的分析结果。
- 新增history_manager.py以管理分析结果的保存和索引。
- 更新async_progress_tracker.py以支持LangChain消息对象的安全序列化。
- 修改sidebar.py中的默认模型ID。