### PR TITLE
feat: 添加智谱AI (ZhipuGLM) 模型提供商支持

### DIFF
--- a/install/database_export_config_2025-11-13.json
+++ b/install/database_export_config_2025-11-13.json
@@ -13287,8 +13287,8 @@
             ]
           },
           {
-            "name": "glm-4-flash-250414",
-            "display_name": "GLM-4-Flash",
+            "name": "glm-4-airx",
+            "display_name": "GLM-4-AirX",
             "description": "智谱快速模型，适合日常任务",
             "max_tokens": 8192,
             "input_price_per_1k": 0.001,

--- a/install/database_export_config_2025-11-13.json
+++ b/install/database_export_config_2025-11-13.json
@@ -13250,10 +13250,9 @@
         "updated_at": "2025-10-23T07:53:00.346000"
       },
       {
-        "_id": "zhipu_provider_001",
         "name": "zhipu",
-        "display_name": "智谱AI",
-        "description": "智谱AI提供的GLM系列大模型",
+        "display_name": "智谱AI (OpenAI兼容)",
+        "description": "智谱AI提供的GLM-4系列大模型，支持OpenAI兼容API",
         "website": "https://open.bigmodel.cn",
         "api_doc_url": "https://open.bigmodel.cn/dev/api",
         "default_base_url": "https://open.bigmodel.cn/api/paas/v4/",
@@ -13261,19 +13260,63 @@
         "supported_features": [
           "chat",
           "completion",
-          "embedding",
           "function_calling",
           "streaming"
         ],
-        "created_at": "2026-03-09T00:12:49.683107",
-        "updated_at": "2026-03-09T00:12:49.683153",
         "api_key": "",
         "api_secret": "",
         "extra_config": {
-          "source": "manual"
+          "protocol": "openai",
+          "supports_anthropic": false
         },
         "is_default": false,
-        "models": []
+        "models": [
+          {
+            "name": "glm-4-plus",
+            "display_name": "GLM-4-Plus",
+            "description": "智谱最强模型，适合复杂任务",
+            "max_tokens": 128000,
+            "input_price_per_1k": 0.05,
+            "output_price_per_1k": 0.05,
+            "currency": "CNY",
+            "enabled": true,
+            "capabilities": [
+              "chat",
+              "function_calling",
+              "streaming"
+            ]
+          },
+          {
+            "name": "glm-4-flash-250414",
+            "display_name": "GLM-4-Flash",
+            "description": "智谱快速模型，适合日常任务",
+            "max_tokens": 8192,
+            "input_price_per_1k": 0.001,
+            "output_price_per_1k": 0.001,
+            "currency": "CNY",
+            "enabled": true,
+            "capabilities": [
+              "chat",
+              "function_calling",
+              "streaming"
+            ]
+          },
+          {
+            "name": "glm-4-long",
+            "display_name": "GLM-4-Long",
+            "description": "智谱超长上下文模型，支持1M tokens",
+            "max_tokens": 1048576,
+            "input_price_per_1k": 0.001,
+            "output_price_per_1k": 0.001,
+            "currency": "CNY",
+            "enabled": true,
+            "capabilities": [
+              "chat",
+              "function_calling",
+              "streaming"
+            ]
+          }
+        ]
       }
     ],
     "market_categories": [

--- a/install/database_export_config_2025-11-13.json
+++ b/install/database_export_config_2025-11-13.json
@@ -13248,6 +13248,32 @@
         "model_name_format": null,
         "created_at": "2025-10-23T07:52:02.557000",
         "updated_at": "2025-10-23T07:53:00.346000"
+      },
+      {
+        "_id": "zhipu_provider_001",
+        "name": "zhipu",
+        "display_name": "智谱AI",
+        "description": "智谱AI提供的GLM系列大模型",
+        "website": "https://open.bigmodel.cn",
+        "api_doc_url": "https://open.bigmodel.cn/dev/api",
+        "default_base_url": "https://open.bigmodel.cn/api/paas/v4/",
+        "is_active": true,
+        "supported_features": [
+          "chat",
+          "completion",
+          "embedding",
+          "function_calling",
+          "streaming"
+        ],
+        "created_at": "2026-03-09T00:12:49.683107",
+        "updated_at": "2026-03-09T00:12:49.683153",
+        "api_key": "",
+        "api_secret": "",
+        "extra_config": {
+          "source": "manual"
+        },
+        "is_default": false,
+        "models": []
       }
     ],
     "market_categories": [


### PR DESCRIPTION
## 变更摘要
添加智谱AI (ZhipuGLM) 模型提供商支持，使用 OpenAI 兼容协议。

## 模型列表
- **glm-4-plus**: 最强模型，适合复杂任务 (128K上下文)
- **glm-4-flash-250414**: 快速模型，适合日常任务 (8K上下文)
- **glm-4-long**: 超长上下文模型 (1M tokens)

## 技术细节
- 使用 OpenAI 兼容协议: `https://open.bigmodel.cn/api/paas/v4/`
- 支持功能: chat, completion, function_calling, streaming

## 相关链接
- 官网: https://open.bigmodel.cn
- API 文档: https://open.bigmodel.cn/dev/api