### PR TITLE
fix: prevent path traversal in log file read, export, and delete (CWE-22)

### DIFF
--- a/app/routers/logs.py
+++ b/app/routers/logs.py
@@ -116,6 +116,8 @@ async def read_log_file(
         
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"❌ 读取日志文件失败: {e}")
         raise HTTPException(status_code=500, detail=f"读取日志文件失败: {str(e)}")
@@ -210,7 +212,9 @@ async def delete_log_file(
         logger.warning(f"🗑️ 用户 {current_user['username']} 删除日志文件: {filename}")
         
         service = get_log_export_service()
-        file_path = service.log_dir / filename
+
+        # 路径安全检查：防止路径遍历
+        file_path = service._validate_log_path(filename)
         
         if not file_path.exists():
             raise HTTPException(status_code=404, detail="日志文件不存在")
@@ -228,7 +232,8 @@ async def delete_log_file(
         
     except HTTPException:
         raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"❌ 删除日志文件失败: {e}")
         raise HTTPException(status_code=500, detail=f"删除日志文件失败: {str(e)}")
-

--- a/app/services/log_export_service.py
+++ b/app/services/log_export_service.py
@@ -42,6 +42,36 @@ class LogExportService:
         else:
             logger.info(f"✅ [LogExportService] 日志目录存在")
 
+    def _validate_log_path(self, filename: str) -> Path:
+        """
+        验证日志文件路径安全性，防止路径遍历攻击
+
+        对文件名进行安全检查，确保解析后的绝对路径位于日志目录内。
+        同时拒绝包含空字节的文件名和解析到目录外的符号链接。
+
+        Args:
+            filename: 日志文件名
+
+        Returns:
+            验证通过的安全文件路径
+
+        Raises:
+            ValueError: 文件名包含非法字符或路径遍历序列
+        """
+        # 拒绝空字节
+        if "\x00" in filename:
+            raise ValueError(f"文件名包含非法字符: {filename}")
+
+        # 构造候选路径并解析为绝对路径（解析 .. 和符号链接）
+        resolved_log_dir = self.log_dir.resolve()
+        file_path = (self.log_dir / filename).resolve()
+
+        # 确保解析后的路径仍在日志目录内
+        if not file_path.is_relative_to(resolved_log_dir):
+            raise ValueError(f"非法的文件路径，禁止访问日志目录之外的文件: {filename}")
+
+        return file_path
+
     def list_log_files(self) -> List[Dict[str, Any]]:
         """
         列出所有日志文件
@@ -148,7 +178,7 @@ class LogExportService:
         Returns:
             日志内容和统计信息
         """
-        file_path = self.log_dir / filename
+        file_path = self._validate_log_path(filename)
         
         if not file_path.exists():
             raise FileNotFoundError(f"日志文件不存在: {filename}")
@@ -238,7 +268,11 @@ class LogExportService:
         try:
             # 确定要导出的文件
             if filenames:
-                files_to_export = [self.log_dir / f for f in filenames if (self.log_dir / f).exists()]
+                files_to_export = []
+                for f in filenames:
+                    validated = self._validate_log_path(f)
+                    if validated.exists():
+                        files_to_export.append(validated)
             else:
                 files_to_export = list(self.log_dir.glob("*.log*"))
             
@@ -475,4 +509,3 @@ def _get_log_directory() -> str:
     except Exception as e:
         logger.error(f"❌ [_get_log_directory] 获取日志目录失败: {e}，使用默认值 ./logs", exc_info=True)
         return "./logs"
-

--- a/tests/test_cwe22_log_path_traversal.py
+++ b/tests/test_cwe22_log_path_traversal.py
@@ -1,0 +1,144 @@
+"""
+PoC test for CWE-22: Path traversal in LogExportService.
+
+Tests that read_log_file, export_logs, and delete_log_file properly
+reject filenames containing path traversal sequences.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Add the project root to sys.path so we can import the service
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+
+
+import pytest
+
+
+@pytest.fixture
+def service_with_secret(tmp_path):
+    """
+    Create a LogExportService with a controlled log directory,
+    and place a secret file outside the log directory to prove traversal.
+    """
+    from app.services.log_export_service import LogExportService
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    # Create a legitimate log file inside log_dir
+    legit_log = log_dir / "app.log"
+    legit_log.write_text("INFO: test log entry\n")
+
+    # Create a sensitive file OUTSIDE the log directory
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("SECRET_DATA_SHOULD_NOT_BE_READABLE")
+
+    # Create a .log file outside log_dir (for delete bypass test)
+    outside_log = tmp_path / "outside.log"
+    outside_log.write_text("OUTSIDE_LOG_DATA")
+
+    service = LogExportService(log_dir=str(log_dir))
+    return service, log_dir, secret_file, outside_log, tmp_path
+
+
+class TestPathTraversalRead:
+    """Tests for path traversal in read_log_file."""
+
+    def test_read_traversal_relative(self, service_with_secret):
+        """read_log_file with '../secret.txt' should be blocked."""
+        service, log_dir, secret_file, _, _ = service_with_secret
+        # Verify the secret is reachable via traversal
+        traversal_path = log_dir / "../secret.txt"
+        assert traversal_path.resolve().exists(), "Precondition: secret file must exist"
+
+        with pytest.raises((ValueError, FileNotFoundError, PermissionError)):
+            service.read_log_file(filename="../secret.txt")
+
+    def test_read_traversal_absolute(self, service_with_secret):
+        """read_log_file with an absolute path should be blocked."""
+        service, _, secret_file, _, _ = service_with_secret
+
+        with pytest.raises((ValueError, FileNotFoundError, PermissionError)):
+            service.read_log_file(filename=str(secret_file))
+
+    def test_read_traversal_double_dot(self, service_with_secret):
+        """read_log_file with nested traversal should be blocked."""
+        service, _, _, _, tmp_path = service_with_secret
+        with pytest.raises((ValueError, FileNotFoundError, PermissionError)):
+            service.read_log_file(filename="subdir/../../secret.txt")
+
+    def test_read_legitimate_file(self, service_with_secret):
+        """read_log_file with a normal log filename should work."""
+        service, _, _, _, _ = service_with_secret
+        result = service.read_log_file(filename="app.log")
+        assert result["filename"] == "app.log"
+        assert any("test log entry" in line for line in result["lines"])
+
+
+class TestPathTraversalExport:
+    """Tests for path traversal in export_logs."""
+
+    def test_export_traversal(self, service_with_secret):
+        """export_logs with traversal filenames should be blocked."""
+        service, log_dir, secret_file, _, _ = service_with_secret
+        traversal_path = log_dir / "../secret.txt"
+        assert traversal_path.resolve().exists()
+
+        with pytest.raises((ValueError, FileNotFoundError, PermissionError)):
+            service.export_logs(filenames=["../secret.txt"])
+
+
+class TestPathTraversalDelete:
+    """Tests for path traversal in the delete endpoint."""
+
+    def test_validate_log_path_rejects_traversal(self, service_with_secret):
+        """
+        _validate_log_path with '../outside.log' should raise even though
+        the filename ends with .log.
+        """
+        service, log_dir, _, outside_log, _ = service_with_secret
+        assert outside_log.exists(), "Precondition: outside.log must exist"
+
+        try:
+            validated = service._validate_log_path("../outside.log")
+            pytest.fail("_validate_log_path should have rejected '../outside.log'")
+        except AttributeError:
+            pytest.fail(
+                "_validate_log_path method does not exist; "
+                "path traversal protection is missing"
+            )
+        except (ValueError, PermissionError):
+            pass  # Expected after fix
+
+
+class TestVariantAttackPaths:
+    """Adjacent attack surface: symlinks and encoding variants."""
+
+    def test_symlink_escape(self, service_with_secret):
+        """A symlink inside log_dir pointing outside should be blocked."""
+        service, log_dir, secret_file, _, _ = service_with_secret
+
+        # Create a symlink inside log_dir -> secret file
+        symlink_path = log_dir / "evil.log"
+        try:
+            symlink_path.symlink_to(secret_file)
+        except OSError:
+            pytest.skip("Cannot create symlinks on this platform")
+
+        # After fix, reading a symlink that resolves outside should fail
+        with pytest.raises((ValueError, FileNotFoundError, PermissionError)):
+            service.read_log_file(filename="evil.log")
+
+    def test_null_byte_injection(self, service_with_secret):
+        """Filenames with null bytes should be rejected."""
+        service, _, _, _, _ = service_with_secret
+        with pytest.raises((ValueError, FileNotFoundError, PermissionError, OSError)):
+            service.read_log_file(filename="app.log\x00../../etc/passwd")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Fix: Path Traversal in Log File Read, Export, and Delete (CWE-22)

### Vulnerability Summary

| Field | Value |
|---|---|
| **CWE** | [CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')](https://cwe.mitre.org/data/definitions/22.html) |
| **Severity** | High |
| **Affected files** | `app/services/log_export_service.py`, `app/routers/logs.py` |
| **Endpoints** | `POST /api/system/system-logs/read`, `POST /api/system/system-logs/export`, `DELETE /api/system/system-logs/files/{filename}` |

**Data flow:** User-controlled `filename` (from JSON body or URL path parameter) → `os.path.join(log_dir, filename)` → file read / zip export / delete — with **no path validation or canonicalization**.

An authenticated user (any role — no admin check) can supply filenames containing `../` sequences to read arbitrary files within the container, including `/proc/self/environ` (which contains database credentials), `/etc/passwd`, application source code, and host-mounted config files exposed via Docker volume mounts.

### Exploit Example

```bash
# Read /proc/self/environ (contains TRADINGAGENTS_MONGODB_URL with credentials)
curl -X POST 'http://target:8000/api/system/system-logs/read' \
  -H 'Authorization: Bearer <any_valid_token>' \
  -H 'Content-Type: application/json' \
  -d '{"filename": "../../proc/self/environ", "lines": 10000}'

# Exfiltrate config files as zip
curl -X POST 'http://target:8000/api/system/system-logs/export' \
  -H 'Authorization: Bearer <any_valid_token>' \
  -H 'Content-Type: application/json' \
  -d '{"filenames": ["../../.env", "../../config/logging.toml"], "format": "zip"}' \
  -o stolen_config.zip
```

### Preconditions

1. Valid JWT token for **any** authenticated user (no admin role required)
2. Network access to port 8000 (Docker publishes this directly; `ALLOWED_ORIGINS: ["*"]`)

### Impact

- **Information disclosure (HIGH):** Arbitrary file read within the container
- **Credential theft:** `/proc/self/environ` exposes `TRADINGAGENTS_MONGODB_URL` (with `admin:tradingagents123`) and Redis passwords
- **Lateral movement:** Stolen DB credentials enable direct MongoDB/Redis access
- **Limited file deletion:** `DELETE` endpoint can remove files ending in `.log` outside the logs directory

---

### Fix Description

**Added `_validate_log_path()`** to `LogExportService` that:

1. Rejects filenames containing null bytes (`\x00`)
2. Resolves the candidate path to its absolute canonical form using `Path.resolve()` (resolves `../`, symlinks)
3. Verifies the resolved path is within the log directory using `Path.is_relative_to()`
4. Raises `ValueError` if validation fails

**Applied the validation to all three user-input-to-filesystem paths:**

| Method / Endpoint | Before | After |
|---|---|---|
| `read_log_file()` | `self.log_dir / filename` | `self._validate_log_path(filename)` |
| `export_logs()` loop | `self.log_dir / f` | `self._validate_log_path(f)` |
| `DELETE /files/{filename}` router | `service.log_dir / filename` | `service._validate_log_path(filename)` |

**Rationale:** `Path.resolve()` + `is_relative_to()` is the standard Python pattern for preventing path traversal. It handles all known bypass techniques (double-dot sequences, symlink escapes, encoding variants). The `ValueError` is caught by new exception handlers in `logs.py` and returned as HTTP 400.

### Files Changed

- **`app/services/log_export_service.py`** — Added `_validate_log_path()` method; replaced direct path construction in `read_log_file()` and `export_logs()`
- **`app/routers/logs.py`** — Applied `_validate_log_path()` in `delete_log_file`; added `ValueError` → HTTP 400 handlers
- **`tests/test_cwe22_log_path_traversal.py`** — New: 8 test cases covering the vulnerability and fix

---

### Test Results

```
tests/test_cwe22_log_path_traversal.py::TestPathTraversalRead::test_read_traversal_relative       PASSED
tests/test_cwe22_log_path_traversal.py::TestPathTraversalRead::test_read_traversal_absolute       PASSED
tests/test_cwe22_log_path_traversal.py::TestPathTraversalRead::test_read_traversal_double_dot     PASSED
tests/test_cwe22_log_path_traversal.py::TestPathTraversalRead::test_read_legitimate_file          PASSED
tests/test_cwe22_log_path_traversal.py::TestPathTraversalExport::test_export_traversal            PASSED
tests/test_cwe22_log_path_traversal.py::TestPathTraversalDelete::test_validate_log_path_rejects_traversal  PASSED
tests/test_cwe22_log_path_traversal.py::TestVariantAttackPaths::test_symlink_escape               PASSED
tests/test_cwe22_log_path_traversal.py::TestVariantAttackPaths::test_null_byte_injection          PASSED
```

All 8 tests pass. The tests verify:
- Relative traversal (`../secret.txt`) → blocked
- Absolute path injection (`/tmp/.../secret.txt`) → blocked
- Nested traversal (`subdir/../../secret.txt`) → blocked
- Legitimate file access (`app.log`) → still works
- Export with traversal filenames → blocked
- Delete with traversal + `.log` extension → blocked
- Symlink escape (symlink inside log_dir pointing outside) → blocked
- Null byte injection → blocked

---

### Disprove Analysis

We attempted to invalidate this finding through systematic analysis:

| Check | Result |
|---|---|
| **Auth required?** | Yes — but **any** authenticated user qualifies, not admin-only |
| **Network exposure?** | Internet-facing: `0.0.0.0:8000`, `ALLOWED_HOSTS: ["*"]`, `ALLOWED_ORIGINS: ["*"]`, port published in docker-compose |
| **Existing validation?** | None on read/export. DELETE has a `.log` extension check that doesn't prevent traversal |
| **Deployment isolation?** | Docker container, but runs as root with volume mounts (`./config`, `./data`) exposing host files |
| **Prior fixes?** | No security-related commits on affected files |
| **Precondition equivalence?** | **NOT redundant** — authentication alone grants trading app access, NOT arbitrary file read. The vulnerability provides significant privilege escalation (file-system read → credential theft → lateral movement to MongoDB/Redis) |

**Verdict: CONFIRMED_VALID (high confidence)**

The vulnerability is straightforward to exploit, affects all three file-operation endpoints, and the fix is comprehensive using the correct Python idiom. No parallel unprotected paths exist — `list_log_files()` and `get_log_statistics()` use `self.log_dir.glob()` with no user input in the path.

---

### References

- [CWE-22: Path Traversal](https://cwe.mitre.org/data/definitions/22.html)
- [OWASP: Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
- [OWASP Top 10 A01:2021 – Broken Access Control](https://owasp.org/Top10/A01_2021-Broken_Access_Control/)
