### PR TITLE
fix: prevent path traversal in log file endpoints (CWE-22)

### DIFF
--- a/app/routers/logs.py
+++ b/app/routers/logs.py
@@ -4,6 +4,7 @@
 """
 
 import logging
+from pathlib import Path
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
@@ -14,6 +15,44 @@ from app.services.log_export_service import get_log_export_service
 
 router = APIRouter(prefix="/system-logs", tags=["系统日志"])
 logger = logging.getLogger("webapi")
+
+
+def _validate_log_filename(filename: str, log_dir: Path) -> Path:
+    """
+    验证日志文件名，防止路径遍历攻击 (CWE-22)。
+
+    确保：
+      1. 文件名不包含路径分隔符或 ``..`` 序列
+      2. 文件名为非空字符串
+      3. 解析后的绝对路径仍位于 ``log_dir`` 内部
+
+    Args:
+        filename: 用户提供的文件名
+        log_dir: 允许访问的日志根目录
+
+    Returns:
+        经过验证的文件绝对路径 (Path)
+
+    Raises:
+        HTTPException: 文件名非法或越界
+    """
+    if not filename or not isinstance(filename, str):
+        raise HTTPException(status_code=400, detail="文件名不能为空")
+
+    # 拒绝任何路径分隔符或父目录引用
+    if "/" in filename or "\\" in filename or filename in (".", "..") or ".." in filename:
+        raise HTTPException(status_code=400, detail="文件名包含非法字符")
+
+    resolved = (log_dir / filename).resolve()
+    log_dir_resolved = log_dir.resolve()
+
+    # 容器检查：解析后的路径必须位于 log_dir 内
+    try:
+        resolved.relative_to(log_dir_resolved)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="访问的路径超出日志目录范围")
+
+    return resolved
 
 
 # 请求模型
@@ -103,6 +142,8 @@ async def read_log_file(
         logger.info(f"📖 用户 {current_user['username']} 读取日志文件: {request.filename}")
         
         service = get_log_export_service()
+        # 路径遍历防护 (CWE-22)
+        _validate_log_filename(request.filename, service.log_dir)
         content = service.read_log_file(
             filename=request.filename,
             lines=request.lines,
@@ -114,6 +155,8 @@ async def read_log_file(
         
         return content
         
+    except HTTPException:
+        raise
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
@@ -142,6 +185,12 @@ async def export_logs(
         logger.info(f"📤 用户 {current_user['username']} 导出日志文件")
         
         service = get_log_export_service()
+
+        # 路径遍历防护 (CWE-22)：逐个验证请求的文件名
+        if request.filenames:
+            for fn in request.filenames:
+                _validate_log_filename(fn, service.log_dir)
+
         export_path = service.export_logs(
             filenames=request.filenames,
             level=request.level,
@@ -162,6 +211,8 @@ async def export_logs(
             headers={"Content-Disposition": f"attachment; filename={filename}"}
         )
         
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -210,7 +261,9 @@ async def delete_log_file(
         logger.warning(f"🗑️ 用户 {current_user['username']} 删除日志文件: {filename}")
         
         service = get_log_export_service()
-        file_path = service.log_dir / filename
+
+        # 路径遍历防护 (CWE-22)：验证文件名并解析至 log_dir 内
+        file_path = _validate_log_filename(filename, service.log_dir)
         
         if not file_path.exists():
             raise HTTPException(status_code=404, detail="日志文件不存在")
@@ -231,4 +284,3 @@ async def delete_log_file(
     except Exception as e:
         logger.error(f"❌ 删除日志文件失败: {e}")
         raise HTTPException(status_code=500, detail=f"删除日志文件失败: {str(e)}")
-


### PR DESCRIPTION
## Summary

Path traversal vulnerability (CWE-22) in the log management endpoints of `app/routers/logs.py`. An authenticated user can read arbitrary files from the container filesystem and delete files with `.log` extensions outside the intended log directory.

**Severity:** High
**CWE:** [CWE-22 — Improper Limitation of a Pathname to a Restricted Directory](https://cwe.mitre.org/data/definitions/22.html)

## Vulnerability Details

### Affected Endpoints

| Endpoint | Method | Parameter | Impact |
|---|---|---|---|
| `/system-logs/read` | POST | `request.filename` (body) | Arbitrary file read |
| `/system-logs/export` | POST | `request.filenames` (body) | Arbitrary file read via export |
| `/system-logs/files/{filename}` | DELETE | `filename` (path) | Arbitrary `.log` file deletion |

### Data Flow

1. User-controlled `filename` arrives via request body or URL path parameter
2. Value is passed directly to `service.log_dir / filename` (or `service.read_log_file(filename=...)`)
3. No validation for `..`, `/`, or `\` sequences
4. `pathlib.Path.__truediv__` resolves `../../etc/passwd` to a path outside the log directory
5. File contents are returned to the caller or file is deleted

### Exploit Example

```bash
# Read /etc/passwd from container
curl -X POST http://target:8000/system-logs/read \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"filename": "../../etc/passwd", "lines": 100}'

# Delete a file outside logs dir
curl -X DELETE http://target:8000/system-logs/files/..%2F..%2Fapp%2Fdata%2Fsome.log \
  -H "Authorization: Bearer <token>"
```

## Fix Description

Adds a `_validate_log_filename()` function that:

1. **Rejects path separators and `..` sequences** in the raw filename string — fast-fail for obvious traversal attempts
2. **Resolves the canonical path** via `Path.resolve()` and verifies it remains within the log directory using `is_relative_to()` — prevents bypasses via symlinks or encoding tricks

The validation is applied at the router layer to all three affected endpoints (`read_log_file`, `export_logs`, `delete_log_file`) before any filesystem operation occurs.

### Why this approach

- **Defense in depth:** Both string-level rejection and canonical path verification
- **Minimal change:** Single validation function, three call sites, no architectural changes
- **No false positives:** Legitimate log filenames (e.g., `app_2024-01-15.log`) contain no path separators or `..`

## Test Results

| Input | Expected | Result |
|---|---|---|
| `app.log` | ✅ Allowed | Pass |
| `../../etc/passwd` | ❌ 400 Bad Request | Pass |
| `../../../etc/shadow` | ❌ 400 Bad Request | Pass |
| `foo/../../etc/passwd` | ❌ 400 Bad Request | Pass |
| `....//....//etc/passwd` | ❌ 400 Bad Request | Pass |
| `app.log` (normal use) | ✅ Allowed | Pass |

## Disprove Analysis

We attempted to invalidate this finding through systematic checks:

| Check | Result |
|---|---|
| **Auth required?** | Yes — `get_current_user` on all endpoints. Limits to authenticated users but does NOT prevent exploitation. |
| **Network exposure?** | Port 8000, CORS middleware — potentially internet-facing |
| **Deployment context?** | Docker with volume mounts (`./logs`, `./config`, `./data`) — traversal reaches mounted host dirs |
| **Input sanitization?** | None before fix |
| **Precondition equivalence?** | Auth grants log viewing only; traversal escalates to arbitrary file read/delete. **Not redundant.** |

### Verdict: **CONFIRMED_VALID** (High confidence)

Authentication alone does not grant arbitrary file access. This vulnerability provides significant privilege escalation from "view logs" to "read any file on the container filesystem."

## References

- [OWASP Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
- [CWE-22](https://cwe.mitre.org/data/definitions/22.html)