### PR TITLE
fix: add authentication to social media API endpoints (CWE-862)

### DIFF
--- a/app/routers/social_media.py
+++ b/app/routers/social_media.py
@@ -4,7 +4,7 @@
 """
 from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Query
+from fastapi import APIRouter, HTTPException, BackgroundTasks, Depends, Query
 from pydantic import BaseModel, Field
 
 from app.services.social_media_service import (
@@ -12,6 +12,7 @@ from app.services.social_media_service import (
     SocialMediaQueryParams,
     SocialMediaStats
 )
+from app.routers.auth_db import get_current_user
 from app.core.response import ok
 
 router = APIRouter(prefix="/api/social-media", tags=["social-media"])
@@ -66,7 +67,10 @@ class SocialMediaQueryRequest(BaseModel):
 
 
 @router.post("/save", response_model=dict)
-async def save_social_media_messages(request: SocialMediaBatchRequest):
+async def save_social_media_messages(
+    request: SocialMediaBatchRequest,
+    current_user: dict = Depends(get_current_user)
+):
     """批量保存社媒消息"""
     try:
         service = await get_social_media_service()
@@ -91,7 +95,10 @@ async def save_social_media_messages(request: SocialMediaBatchRequest):
 
 
 @router.post("/query", response_model=dict)
-async def query_social_media_messages(request: SocialMediaQueryRequest):
+async def query_social_media_messages(
+    request: SocialMediaQueryRequest,
+    current_user: dict = Depends(get_current_user)
+):
     """查询社媒消息"""
     try:
         service = await get_social_media_service()
@@ -135,7 +142,8 @@ async def query_social_media_messages(request: SocialMediaQueryRequest):
 async def get_latest_messages(
     symbol: str,
     platform: Optional[str] = Query(None, description="平台类型"),
-    limit: int = Query(20, ge=1, le=100, description="返回数量")
+    limit: int = Query(20, ge=1, le=100, description="返回数量"),
+    current_user: dict = Depends(get_current_user)
 ):
     """获取最新社媒消息"""
     try:
@@ -160,7 +168,8 @@ async def search_messages(
     query: str = Query(..., description="搜索关键词"),
     symbol: Optional[str] = Query(None, description="股票代码"),
     platform: Optional[str] = Query(None, description="平台类型"),
-    limit: int = Query(50, ge=1, le=200, description="返回数量")
+    limit: int = Query(50, ge=1, le=200, description="返回数量"),
+    current_user: dict = Depends(get_current_user)
 ):
     """全文搜索社媒消息"""
     try:
@@ -185,7 +194,8 @@ async def search_messages(
 @router.get("/statistics", response_model=dict)
 async def get_statistics(
     symbol: Optional[str] = Query(None, description="股票代码"),
-    hours_back: int = Query(24, ge=1, le=168, description="回溯小时数")
+    hours_back: int = Query(24, ge=1, le=168, description="回溯小时数"),
+    current_user: dict = Depends(get_current_user)
 ):
     """获取社媒消息统计信息"""
     try:
@@ -266,7 +276,8 @@ async def get_supported_platforms():
 async def get_sentiment_analysis(
     symbol: str,
     platform: Optional[str] = Query(None, description="平台类型"),
-    hours_back: int = Query(24, ge=1, le=168, description="回溯小时数")
+    hours_back: int = Query(24, ge=1, le=168, description="回溯小时数"),
+    current_user: dict = Depends(get_current_user)
 ):
     """获取股票的社媒情绪分析"""
     try:


### PR DESCRIPTION
## Vulnerability Summary

**CWE-862: Missing Authorization** | Severity: **High**

The `social_media.py` router exposes 6 data-accessing endpoints without any authentication, while **every other router** in the project (`news_data.py`, `stocks.py`, `tags.py`, `queue.py`, `stock_sync.py`, `config.py`) consistently uses `Depends(get_current_user)`.

### Data Flow

```
Attacker (no credentials) → HTTP request → 0.0.0.0:8000 → /api/social-media/* → read/write social media data
```

### Affected Endpoints

| Endpoint | Method | Impact |
|----------|--------|--------|
| `/api/social-media/save` | POST | **Write** — inject fake sentiment data |
| `/api/social-media/query` | POST | Read — query all social media messages |
| `/api/social-media/latest/{symbol}` | GET | Read — get latest messages |
| `/api/social-media/search` | GET | Read — full-text search |
| `/api/social-media/statistics` | GET | Read — message statistics |
| `/api/social-media/sentiment/{symbol}` | GET | Read — sentiment analysis data |

### Exploitation

No authentication required. Anyone with network access to port 8000 can read and write social media sentiment data:

```bash
# Write fake sentiment data (no auth needed)
curl -X POST http://target:8000/api/social-media/save \
  -H "Content-Type: application/json" \
  -d '{"symbol":"000001","messages":[{"message_id":"1","platform":"weibo","content":"fake news","author":{},"engagement":{},"publish_time":"2024-01-01T00:00:00Z","data_source":"attacker"}]}'

# Read data (no auth needed)
curl http://target:8000/api/social-media/latest/000001
```

### Contributing Factors

- App binds to `0.0.0.0:8000`
- `ALLOWED_HOSTS` defaults to `["*"]`
- Docker-compose exposes port 8000 directly
- CORS configured with credentials support

---

## Fix Description

Added `Depends(get_current_user)` to all 6 data-accessing endpoints in `social_media.py`, matching the exact authentication pattern used consistently across every other router in the project.

**Changes:**
- Import `Depends` from `fastapi` and `get_current_user` from `app.routers.auth_db`
- Add `current_user: dict = Depends(get_current_user)` parameter to: `save_social_media_messages`, `query_social_media_messages`, `get_latest_messages`, `search_messages`, `get_statistics`, `get_sentiment_analysis`

**Not modified:** `get_supported_platforms()` — returns static platform list, no sensitive data.

**Rationale:** This is the minimal, consistent fix. The authentication dependency and pattern already exist in the codebase; this router was simply missed.

---

## Test Results

- Verified all 6 endpoints now require authentication via `get_current_user` dependency
- `get_supported_platforms` correctly left unauthenticated (static data only)
- Fix follows identical pattern to all other routers — no new dependencies introduced

---

## Disprove Analysis

We attempted to invalidate this finding through systematic analysis:

| Check | Result |
|-------|--------|
| **Auth already present?** | ❌ No auth on any `social_media.py` endpoint |
| **Network-restricted?** | ❌ Binds `0.0.0.0`, `ALLOWED_HOSTS: ["*"]`, port exposed in Docker |
| **Intermediary proxy with auth?** | ❌ Endpoints directly HTTP-accessible |
| **Input validation sufficient?** | ❌ Pydantic validates shape, not identity |
| **Precondition equivalence?** | ❌ Network access ≠ authenticated access; vulnerability grants unauthorized data read/write |

**Verdict: CONFIRMED_VALID** (high confidence)

The sole precondition is network access to port 8000, which does not grant authenticated access. The missing auth allows unauthenticated read/write of social media sentiment data that could influence trading decisions.