### PR TITLE
Require authentication on /api/internal-messages/* endpoints

### DIFF
--- a/app/routers/internal_messages.py
+++ b/app/routers/internal_messages.py
@@ -4,7 +4,7 @@
 """
 from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Query
+from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Query
 from pydantic import BaseModel, Field
 
 from app.services.internal_message_service import (
@@ -13,6 +13,7 @@ from app.services.internal_message_service import (
     InternalMessageStats
 )
 from app.core.response import ok
+from app.routers.auth_db import get_current_user
 
 router = APIRouter(prefix="/api/internal-messages", tags=["internal-messages"])
 
@@ -75,7 +76,7 @@ class InternalMessageQueryRequest(BaseModel):
 
 
 @router.post("/save", response_model=dict)
-async def save_internal_messages(request: InternalMessageBatchRequest):
+async def save_internal_messages(request: InternalMessageBatchRequest, current_user: dict = Depends(get_current_user)):
     """批量保存内部消息"""
     try:
         service = await get_internal_message_service()
@@ -99,7 +100,7 @@ async def save_internal_messages(request: InternalMessageBatchRequest):
 
 
 @router.post("/query", response_model=dict)
-async def query_internal_messages(request: InternalMessageQueryRequest):
+async def query_internal_messages(request: InternalMessageQueryRequest, current_user: dict = Depends(get_current_user)):
     """查询内部消息"""
     try:
         service = await get_internal_message_service()
@@ -145,7 +146,8 @@ async def get_latest_messages(
     symbol: str,
     message_type: Optional[str] = Query(None, description="消息类型"),
     access_level: Optional[str] = Query(None, description="访问级别"),
-    limit: int = Query(20, ge=1, le=100, description="返回数量")
+    limit: int = Query(20, ge=1, le=100, description="返回数量"),
+    current_user: dict = Depends(get_current_user),
 ):
     """获取最新内部消息"""
     try:
@@ -171,7 +173,8 @@ async def search_messages(
     query: str = Query(..., description="搜索关键词"),
     symbol: Optional[str] = Query(None, description="股票代码"),
     access_level: Optional[str] = Query(None, description="访问级别"),
-    limit: int = Query(50, ge=1, le=200, description="返回数量")
+    limit: int = Query(50, ge=1, le=200, description="返回数量"),
+    current_user: dict = Depends(get_current_user),
 ):
     """全文搜索内部消息"""
     try:
@@ -196,7 +199,8 @@ async def search_messages(
 async def get_research_reports(
     symbol: str,
     department: Optional[str] = Query(None, description="部门"),
-    limit: int = Query(20, ge=1, le=100, description="返回数量")
+    limit: int = Query(20, ge=1, le=100, description="返回数量"),
+    current_user: dict = Depends(get_current_user),
 ):
     """获取研究报告"""
     try:
@@ -220,7 +224,8 @@ async def get_research_reports(
 async def get_analyst_notes(
     symbol: str,
     author: Optional[str] = Query(None, description="分析师"),
-    limit: int = Query(20, ge=1, le=100, description="返回数量")
+    limit: int = Query(20, ge=1, le=100, description="返回数量"),
+    current_user: dict = Depends(get_current_user),
 ):
     """获取分析师笔记"""
     try:
@@ -243,7 +248,8 @@ async def get_analyst_notes(
 @router.get("/statistics", response_model=dict)
 async def get_statistics(
     symbol: Optional[str] = Query(None, description="股票代码"),
-    hours_back: int = Query(24, ge=1, le=168, description="回溯小时数")
+    hours_back: int = Query(24, ge=1, le=168, description="回溯小时数"),
+    current_user: dict = Depends(get_current_user),
 ):
     """获取内部消息统计信息"""
     try:
@@ -272,7 +278,7 @@ async def get_statistics(
 
 
 @router.get("/message-types", response_model=dict)
-async def get_message_types():
+async def get_message_types(current_user: dict = Depends(get_current_user)):
     """获取支持的消息类型列表"""
     message_types = [
         {
@@ -311,7 +317,7 @@ async def get_message_types():
 
 
 @router.get("/categories", response_model=dict)
-async def get_categories():
+async def get_categories(current_user: dict = Depends(get_current_user)):
     """获取支持的分类列表"""
     categories = [
         {
@@ -345,7 +351,7 @@ async def get_categories():
 
 
 @router.get("/health", response_model=dict)
-async def health_check():
+async def health_check(current_user: dict = Depends(get_current_user)):
     """健康检查"""
     try:
         service = await get_internal_message_service()


### PR DESCRIPTION
## Summary

The `/api/internal-messages/*` endpoints in `app/routers/internal_messages.py` are exposed without any authentication. This router is mounted in `app/main.py` and reachable by anyone with network access to the API host. Other sensitive routers in this project (e.g. `auth_db`, configuration, user data) use `Depends(get_current_user)` — this router appears to have simply been missed.

This PR adds `Depends(get_current_user)` to every endpoint in the router so it matches the rest of the codebase.

## Vulnerability details

- **Type:** Missing authentication for critical function (CWE-862)
- **File:** `app/routers/internal_messages.py`
- **Affected endpoints (10):**
  - `POST /api/internal-messages/save` — arbitrary insertion of internal messages, research reports, analyst notes
  - `POST /api/internal-messages/query` — arbitrary query of stored internal messages
  - `GET  /api/internal-messages/latest/{symbol}`
  - `GET  /api/internal-messages/search`
  - `GET  /api/internal-messages/research-reports/{symbol}`
  - `GET  /api/internal-messages/analyst-notes/{symbol}`
  - `GET  /api/internal-messages/statistics`
  - `GET  /api/internal-messages/message-types`
  - `GET  /api/internal-messages/categories`
  - `GET  /api/internal-messages/health`

Impact: Unauthenticated reads expose proprietary internal research data per symbol; unauthenticated writes via `/save` let an attacker poison the internal-message store with fabricated research reports or analyst notes that downstream agents and users would then consume as trusted internal data.

## Fix

Add `current_user: dict = Depends(get_current_user)` to each endpoint, importing the same dependency the rest of the project already uses (`app.routers.auth_db.get_current_user`). No other behavior is changed.

Diff is small and surgical:

```
 app/routers/internal_messages.py | 28 +++++++++++++++++-----------
 1 file changed, 17 insertions(+), 11 deletions(-)
```

## Testing

- Exercised the affected endpoints without an `Authorization` header — all 10 now return `401 Unauthorized` instead of executing.
- Confirmed `get_current_user` is the same dependency used by other authenticated routers in the repo, so header parsing and error shape stay consistent with the rest of the API.
- No public/anonymous flow is intended for this router (it is an internal-messages store), so requiring auth on every endpoint — including `/health`, `/message-types`, `/categories` — is consistent with the router's purpose. If you would prefer `/health` to remain anonymous for liveness probes, happy to split that out in a follow-up.

## Why this is exploitable

The only precondition is network reachability to the API host. There is no upstream auth middleware in `app/main.py` that would otherwise gate this router, and the endpoints don't perform any per-request authorization themselves. Network reachability alone does not grant DB read/write access elsewhere in the app, so this router is a genuine privilege boundary that is currently missing.

## Adversarial review

Before submitting, we tried to disprove this finding: we checked whether some upstream middleware, reverse-proxy assumption, or framework default might already require auth, and whether any other endpoint already exposes the same data such that this router would be redundant to gate. Neither holds — the router is registered directly on the FastAPI app with no auth middleware, and other routers that touch the same data already require `get_current_user`, so this one is an outlier rather than a duplicate path.