### PR TITLE
Add authentication to /api/sync/multi-source endpoints (CWE-862)

### DIFF
--- a/app/routers/multi_source_sync.py
+++ b/app/routers/multi_source_sync.py
@@ -5,9 +5,10 @@ Provides endpoints for multi-source stock data synchronization
 import asyncio
 import logging
 from typing import Dict, List, Optional, Any, Union
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from app.routers.auth_db import get_current_user
 from app.services.multi_source_basics_sync_service import get_multi_source_sync_service
 from app.services.data_sources.manager import DataSourceManager
 
@@ -38,7 +39,7 @@ class DataSourceStatus(BaseModel):
 
 
 @router.get("/sources/status")
-async def get_data_sources_status():
+async def get_data_sources_status(current_user: dict = Depends(get_current_user)):
     """获取所有数据源的状态"""
     try:
         manager = DataSourceManager()
@@ -86,7 +87,7 @@ async def get_data_sources_status():
 
 
 @router.get("/sources/current")
-async def get_current_data_source():
+async def get_current_data_source(current_user: dict = Depends(get_current_user)):
     """获取当前正在使用的数据源（优先级最高且可用的）"""
     try:
         manager = DataSourceManager()
@@ -135,7 +136,7 @@ async def get_current_data_source():
 
 
 @router.get("/status")
-async def get_sync_status():
+async def get_sync_status(current_user: dict = Depends(get_current_user)):
     """获取多数据源同步状态"""
     try:
         service = get_multi_source_sync_service()
@@ -154,7 +155,8 @@ async def get_sync_status():
 @router.post("/stock_basics/run")
 async def run_stock_basics_sync(
     force: bool = Query(False, description="是否强制运行同步"),
-    preferred_sources: Optional[str] = Query(None, description="优先使用的数据源，用逗号分隔")
+    preferred_sources: Optional[str] = Query(None, description="优先使用的数据源，用逗号分隔"),
+    current_user: dict = Depends(get_current_user)
 ):
     """运行多数据源股票基础信息同步"""
     try:
@@ -275,7 +277,10 @@ class TestSourceRequest(BaseModel):
 
 
 @router.post("/test-sources")
-async def test_data_sources(request: TestSourceRequest = TestSourceRequest()):
+async def test_data_sources(
+    request: TestSourceRequest = TestSourceRequest(),
+    current_user: dict = Depends(get_current_user)
+):
     """
     测试数据源的连通性
 
@@ -347,7 +352,7 @@ async def test_data_sources(request: TestSourceRequest = TestSourceRequest()):
 
 
 @router.get("/recommendations")
-async def get_sync_recommendations():
+async def get_sync_recommendations(current_user: dict = Depends(get_current_user)):
     """获取数据源使用建议"""
     try:
         manager = DataSourceManager()
@@ -403,7 +408,8 @@ async def get_sync_recommendations():
 async def get_sync_history(
     page: int = Query(1, ge=1, description="页码"),
     page_size: int = Query(10, ge=1, le=50, description="每页大小"),
-    status: Optional[str] = Query(None, description="状态筛选")
+    status: Optional[str] = Query(None, description="状态筛选"),
+    current_user: dict = Depends(get_current_user)
 ):
     """获取同步历史记录"""
     try:
@@ -446,7 +452,7 @@ async def get_sync_history(
 
 
 @router.delete("/cache")
-async def clear_sync_cache():
+async def clear_sync_cache(current_user: dict = Depends(get_current_user)):
     """清空同步相关的缓存"""
     try:
         service = get_multi_source_sync_service()

--- a/tests/test_multi_source_sync_auth.py
+++ b/tests/test_multi_source_sync_auth.py
@@ -1,0 +1,45 @@
+"""
+PoC test: Verify that multi_source_sync endpoints require authentication.
+Before fix: all requests return 200 (no auth required).
+After fix: requests without auth token return 401.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.multi_source_sync import router
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+UNAUTH_ENDPOINTS = [
+    ("GET", "/api/sync/multi-source/sources/status"),
+    ("GET", "/api/sync/multi-source/sources/current"),
+    ("GET", "/api/sync/multi-source/status"),
+    ("POST", "/api/sync/multi-source/stock_basics/run"),
+    ("POST", "/api/sync/multi-source/test-sources"),
+    ("GET", "/api/sync/multi-source/recommendations"),
+    ("GET", "/api/sync/multi-source/history"),
+    ("DELETE", "/api/sync/multi-source/cache"),
+]
+
+
+@pytest.mark.parametrize("method,path", UNAUTH_ENDPOINTS)
+def test_endpoints_require_auth(client, method, path):
+    """All multi-source sync endpoints must return 401 without a valid token."""
+    if method == "GET":
+        resp = client.get(path)
+    elif method == "POST":
+        resp = client.post(path, json={})
+    elif method == "DELETE":
+        resp = client.delete(path)
+
+    assert resp.status_code == 401, (
+        f"{method} {path} returned {resp.status_code} instead of 401 — "
+        "endpoint is accessible without authentication"
+    )


### PR DESCRIPTION
## Summary

The `/api/sync/multi-source/*` router exposes 8 endpoints that previously had no authentication. This PR adds the project's existing `get_current_user` dependency to each of them, matching the pattern already used by `app/routers/auth_db.py`, `analysis.py`, and the rest of the API surface.

## Vulnerability

- **CWE-862: Missing Authorization**
- **File:** `app/routers/multi_source_sync.py`
- **Affected endpoints (all under prefix `/api/sync/multi-source`):**
  - `GET /sources/status`
  - `GET /sources/current`
  - `GET /status`
  - `POST /stock_basics/run`
  - `POST /test-sources`
  - `GET /recommendations`
  - `GET /history`
  - `DELETE /cache`

`app/main.py` registers only CORS, TrustedHost, OperationLog, and RequestID middlewares — there is no global auth middleware. Authentication on this codebase is enforced per-endpoint via `Depends(get_current_user)`, and these eight endpoints were missing that dependency.

### Impact

Any unauthenticated network client that can reach the API can:

- Trigger expensive upstream data-source synchronisations against Tushare / AKShare (`POST /stock_basics/run`, `POST /test-sources`). These consume third-party API quotas and CPU on the server, so a small number of requests is enough to cause cost / quota exhaustion and degrade service for legitimate users.
- Invalidate the data-source cache (`DELETE /cache`), forcing the server to re-fetch from upstream on the next request — a cheap way to amplify the above.
- Enumerate configured data sources, their availability, priorities, and sync history — useful reconnaissance for follow-on attacks.

## Fix

Add `current_user: dict = Depends(get_current_user)` to each of the eight handler signatures, and import `Depends` plus `get_current_user`. No other behaviour is changed; authenticated callers see identical responses.

```python
from fastapi import APIRouter, Depends, HTTPException, Query
from app.routers.auth_db import get_current_user

@router.get("/sources/status")
async def get_data_sources_status(current_user: dict = Depends(get_current_user)):
    ...
```

This is the same pattern already used elsewhere in the project, so there is nothing new for operators to configure.

## Tests

Added `tests/test_multi_source_sync_auth.py`, which uses FastAPI's `TestClient` to assert that all eight endpoints return **401 Unauthorized** when called without a valid token. The tests pass against the patched router and would fail against the previous version.

No existing tests were modified or broken; the diff is minimal (one router file + one new test file).

## Adversarial review

Before submitting we tried to disprove the finding: we checked whether `app/main.py` adds a global authentication middleware, whether the router is mounted behind some gateway-level auth, or whether the endpoints internally call something that already requires a user context. None of those mitigations are present — the router was reachable directly and the handlers never touched any auth primitive. We also confirmed that the project already has a working `get_current_user` dependency and uses it on the sensitive routers, so this is genuinely an oversight on one router rather than an intentional public surface.

We noticed that a few neighbouring routers (`sync.py`, `multi_period_sync.py`, `historical_data.py`, `financial_data.py`) appear to have similar gaps. Those are deliberately left out of this PR to keep the change minimal and reviewable; happy to follow up separately if you'd like.