### PR TITLE
fix: 修复开发启动脚本日志乱码

### DIFF
--- a/start_dev.ps1
+++ b/start_dev.ps1
@@ -116,9 +116,31 @@ if (-not $pythonExe) {
 $env:PYTHONIOENCODING = "utf-8"
 $env:PYTHONUTF8 = "1"
 $env:PYTHONUNBUFFERED = "1"  # Disable output buffering
+try {
+    [Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    chcp 65001 > $null
+} catch {
+    Write-Host "[WARN] Failed to switch console code page to UTF-8: $_" -ForegroundColor Yellow
+}
 
 Write-Host "[OK] UTF-8 encoding enabled" -ForegroundColor Green
 Write-Host ""
+
+function Start-DevJob {
+    param(
+        [string]$Name,
+        [scriptblock]$ScriptBlock,
+        [object[]]$ArgumentList
+    )
+
+    if (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue) {
+        return Start-ThreadJob -Name $Name -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+    }
+
+    Write-Host "[WARN] Start-ThreadJob not available; falling back to Start-Job. Console logs may show mojibake on Windows." -ForegroundColor Yellow
+    return Start-Job -Name $Name -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+}
 
 # Check required files
 $backendMain = Join-Path $root "app\main.py"
@@ -147,12 +169,17 @@ try {
         Write-Host ""
 
         # Start Backend using Uvicorn
-        $backendJob = Start-Job -ScriptBlock {
+        $backendJob = Start-DevJob -Name "TradingAgentsBackend" -ScriptBlock {
             param($pythonExe, $backendPort, $root)
             Set-Location $root
             $env:PYTHONIOENCODING = "utf-8"
             $env:PYTHONUTF8 = "1"
             $env:PYTHONUNBUFFERED = "1"
+            try {
+                [Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)
+                [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+                chcp 65001 > $null
+            } catch {}
             & $pythonExe -m uvicorn app.main:app --host 127.0.0.1 --port $backendPort --log-level info
         } -ArgumentList $pythonExe, $BackendPort, $root
 
@@ -171,12 +198,17 @@ try {
         Write-Host ""
 
         # Start Worker using Uvicorn (same as Backend)
-        $workerJob = Start-Job -ScriptBlock {
+        $workerJob = Start-DevJob -Name "TradingAgentsWorker" -ScriptBlock {
             param($pythonExe, $workerPort, $root)
             Set-Location $root
             $env:PYTHONIOENCODING = "utf-8"
             $env:PYTHONUTF8 = "1"
             $env:PYTHONUNBUFFERED = "1"
+            try {
+                [Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false)
+                [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+                chcp 65001 > $null
+            } catch {}
             & $pythonExe -m uvicorn app.worker.worker_app:app --host 127.0.0.1 --port $workerPort --log-level info
         } -ArgumentList $pythonExe, $WorkerPort, $root
 


### PR DESCRIPTION
## 变更

- 开发启动脚本设置 PowerShell 控制台输入/输出编码为 UTF-8，并切换代码页到 65001。
- 后端和 Worker 后台任务优先使用 `Start-ThreadJob`，避免 `Start-Job`/`Receive-Job` 在 Windows 上转发 UTF-8 日志时产生乱码。
- 保留 `Start-Job` 回退路径，并在回退时提示控制台日志可能出现 mojibake。

## 原因

Windows PowerShell 的 `Start-Job` 会在独立进程中捕获子进程输出，`Receive-Job` 转发 UTF-8 中文和 emoji 日志时可能按 CP936/GBK 解码，导致类似 `馃攧 [姝ラ3]` 的乱码。`Start-ThreadJob` 在当前会话内转发输出，可以保留 UTF-8 文本。

## 验证

- `./start_dev.ps1 -Help`
- 最小复现验证：相同 Python UTF-8 输出在 `Start-Job` 下乱码，在 `Start-ThreadJob` 下正常。