### PR TITLE
fix: 补充 DeepSeek V4 模型目录

### DIFF
--- a/app/services/config_service.py
+++ b/app/services/config_service.py
@@ -2580,6 +2580,14 @@ class ConfigService:
                 "provider_name": "DeepSeek",
                 "models": [
                     {
+                        "name": "deepseek-v4-flash",
+                        "display_name": "DeepSeek V4 Flash - 快速版",
+                        "input_price_per_1k": 0.0,
+                        "output_price_per_1k": 0.0,
+                        "context_length": 32768,
+                        "currency": "CNY"
+                    },
+                    {
                         "name": "deepseek-chat",
                         "display_name": "DeepSeek Chat - 通用对话",
                         "input_price_per_1k": 0.0001,

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -53,10 +53,12 @@ MODEL_OPTIONS: ProviderModeOptions = {
     },
     "deepseek": {
         "quick": [
+            ("DeepSeek V4 Flash", "deepseek-v4-flash"),
             ("DeepSeek Chat", "deepseek-chat"),
             ("Custom model ID", "custom"),
         ],
         "deep": [
+            ("DeepSeek V4 Pro", "deepseek-v4-pro"),
             ("DeepSeek Chat", "deepseek-chat"),
             ("DeepSeek Reasoner", "deepseek-reasoner"),
             ("Custom model ID", "custom"),


### PR DESCRIPTION
## Summary
- Add DeepSeek V4 entries to the lightweight model catalog so provider validation recognizes current DeepSeek model IDs.
- Add `deepseek-v4-flash` to the WebAPI default DeepSeek model catalog.

## Root Cause
`deepseek-v4-flash` was only represented under the Volcengine coding provider in the lightweight catalog, and was missing from the WebAPI default DeepSeek catalog. Selecting the DeepSeek provider with that model could therefore be treated as an unknown model or appear unavailable in catalog-driven UI flows.

## Validation
- `python -m py_compile app\services\config_service.py tradingagents\llm_clients\model_catalog.py`
- `git diff --check -- app/services/config_service.py tradingagents/llm_clients/model_catalog.py`
- Verified `validate_model("deepseek", "deepseek-v4-flash")` and `validate_model("deepseek", "deepseek-v4-pro")` return `True`.