### PR TITLE
fix: update DeepSeek demo adapter import

### DIFF
--- a/examples/demo_deepseek_analysis.py
+++ b/examples/demo_deepseek_analysis.py
@@ -48,10 +48,10 @@ def demo_simple_chat():
     logger.info(f"\n🤖 演示DeepSeek V3简单对话...")
     
     try:
-        from tradingagents.llm_adapters.deepseek_direct_adapter import create_deepseek_direct_adapter
+        from tradingagents.llm_adapters.deepseek_adapter import create_deepseek_llm
         
         # 创建DeepSeek模型
-        llm = create_deepseek_direct_adapter(
+        llm = create_deepseek_llm(
             model="deepseek-chat",
             temperature=0.1,
             max_tokens=500
@@ -81,10 +81,10 @@ def demo_reasoning_analysis():
     logger.info(f"\n🧠 演示DeepSeek V3推理分析...")
     
     try:
-        from tradingagents.llm_adapters.deepseek_direct_adapter import create_deepseek_direct_adapter
+        from tradingagents.llm_adapters.deepseek_adapter import create_deepseek_llm
         
         # 创建DeepSeek适配器
-        adapter = create_deepseek_direct_adapter(
+        adapter = create_deepseek_llm(
             model="deepseek-chat",
             temperature=0.1,
             max_tokens=1000
@@ -124,7 +124,7 @@ def demo_stock_analysis_with_tools():
     logger.info(f"\n📊 演示DeepSeek V3工具调用股票分析...")
     
     try:
-        from tradingagents.llm_adapters.deepseek_direct_adapter import create_deepseek_direct_adapter
+        from tradingagents.llm_adapters.deepseek_adapter import create_deepseek_llm
         # 移除langchain工具导入以避免兼容性问题
         
         # 定义股票分析工具（简化版本，不使用langchain装饰器）
@@ -148,7 +148,7 @@ def demo_stock_analysis_with_tools():
             return f"股票{symbol}当前市场情绪：中性偏乐观，机构持仓比例65%"
         
         # 创建DeepSeek适配器
-        adapter = create_deepseek_direct_adapter(
+        adapter = create_deepseek_llm(
             model="deepseek-chat",
             temperature=0.1,
             max_tokens=1000
@@ -204,10 +204,10 @@ def demo_trading_system():
     logger.info(f"\n🎯 演示DeepSeek V3完整交易分析系统...")
     
     try:
-        from tradingagents.llm_adapters.deepseek_direct_adapter import create_deepseek_direct_adapter
+        from tradingagents.llm_adapters.deepseek_adapter import create_deepseek_llm
         
         # 创建DeepSeek适配器
-        adapter = create_deepseek_direct_adapter()
+        adapter = create_deepseek_llm()
         
         # 模拟交易分析查询
         trading_query = "请分析苹果公司(AAPL)的投资价值，包括技术面、基本面和风险评估"

--- a/tests/test_demo_deepseek_analysis_imports.py
+++ b/tests/test_demo_deepseek_analysis_imports.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+
+
+def test_demo_deepseek_analysis_references_existing_adapter_modules():
+    demo_path = Path(__file__).resolve().parents[1] / "examples" / "demo_deepseek_analysis.py"
+    tree = ast.parse(demo_path.read_text(encoding="utf-8"))
+
+    adapter_imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module
+        and node.module.startswith("tradingagents.llm_adapters.")
+    ]
+
+    adapters_dir = demo_path.parents[1] / "tradingagents" / "llm_adapters"
+
+    assert adapter_imports
+    for import_node in adapter_imports:
+        module_name = import_node.module
+        module_file = adapters_dir / f"{module_name.rsplit('.', 1)[-1]}.py"
+        assert module_file.exists(), module_name
+
+        module_tree = ast.parse(module_file.read_text(encoding="utf-8"))
+        exported_names = {
+            node.name for node in module_tree.body if isinstance(node, (ast.FunctionDef, ast.ClassDef))
+        }
+        exported_names.update(
+            target.id
+            for node in module_tree.body
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        )
+        for alias in import_node.names:
+            assert alias.name in exported_names, f"{module_name}.{alias.name}"


### PR DESCRIPTION
## Summary
- update `examples/demo_deepseek_analysis.py` to import the existing `deepseek_adapter` module
- use the existing `create_deepseek_llm` factory instead of the missing `deepseek_direct_adapter`
- add a static regression test that verifies example adapter imports point at real adapter modules and exported names

## Validation
- `uv run --no-sync pytest tests/test_demo_deepseek_analysis_imports.py -q` — 1 passed
- `uv run --no-sync python -m py_compile examples/demo_deepseek_analysis.py tests/test_demo_deepseek_analysis_imports.py`
- `git diff --check`

Replaces #706, whose branch history unintentionally included the full upstream history.

Fixes #702