### PR TITLE
fix: 修复 4 处导致分析静默产出错误结果的缺陷

### DIFF
--- a/app/services/simple_analysis_service.py
+++ b/app/services/simple_analysis_service.py
@@ -1540,7 +1540,11 @@ class SimpleAnalysisService:
 
             # 执行实际分析，传递进度回调和task_id
             state, decision = trading_graph.propagate(
-                request.stock_code,
+                # 🔧 修复：request.stock_code 是 schema 标注「已废弃，请用 symbol」的字段。
+                # 只传 symbol 的客户端会让 ticker 变成 None，整轮分析跑在「股票None」上
+                # 且最终仍标记成功。本文件 771/847 行用的都是兼容取值 get_symbol()。
+                # 上游 pro/main 分支已用同样方式修复（注释：使用 stock_code 变量而不是 request.stock_code）。
+                request.get_symbol(),
                 analysis_date,
                 progress_callback=graph_progress_callback,
                 task_id=task_id
@@ -1823,8 +1827,11 @@ class SimpleAnalysisService:
             # 构建结果
             result = {
                 "analysis_id": str(uuid.uuid4()),
-                "stock_code": request.stock_code,
-                "stock_symbol": request.stock_code,  # 添加stock_symbol字段以保持兼容性
+                # 🔧 修复：同 propagate 处，request.stock_code 是已废弃字段。只传 symbol 的
+                # 客户端会让结果里的 stock_code/stock_symbol 变成 None，最终在
+                # app/routers/analysis.py:647-648 被 safe_string 兜底成 "UNKNOWN"。
+                "stock_code": request.get_symbol(),
+                "stock_symbol": request.get_symbol(),  # 添加stock_symbol字段以保持兼容性
                 "analysis_date": analysis_date,
                 "summary": summary,
                 "recommendation": recommendation,

--- a/app/services/unified_stock_service.py
+++ b/app/services/unified_stock_service.py
@@ -186,7 +186,11 @@ class UnifiedStockService:
         }
 
         # 查询所有匹配的记录
-        cursor = collection.find(filter_query)
+        # 🔧 修复：漏了 {"_id": 0} 投影，返回的 doc 带 ObjectId，FastAPI 序列化直接抛
+        # "Unable to serialize unknown type: <class 'bson.objectid.ObjectId'>"，
+        # 导致 GET /api/markets/{market}/stocks/search 只要命中结果就 500（空结果反而正常）。
+        # 本文件其余 6 处 find/find_one 都带了该投影，只有这里漏掉。
+        cursor = collection.find(filter_query, {"_id": 0})
         all_results = await cursor.to_list(length=None)
         
         if not all_results:

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -336,8 +336,15 @@ def create_news_analyst(llm, toolkit):
             logger.info(f"[新闻分析师] LLM调用了 {current_tool_calls} 个工具")
             logger.debug(f"📊 [DEBUG] 累计工具调用次数: {tool_call_count}/{max_tool_calls}")
 
-            if current_tool_calls == 0:
-                logger.warning(f"[新闻分析师] ⚠️ {llm.__class__.__name__} 没有调用任何工具，启动补救机制...")
+            # 🔧 修复：模型「正常发起工具调用」时，result.content 只是「我将立即获取…」这类开场白。
+            # 本节点最终返回的是不含 tool_calls 的 clean_message，工具调用不会被任何地方执行，
+            # 上游却把这段开场白直接当成最终报告（实测 news_report 恒为 30 字符）并标记成功。
+            # 因此把判据从「有没有调用工具」改成「有没有拿到可用报告」，两种情况统一走下面
+            # 已有且已验证的强制补救路径：主动调统一新闻工具 + 二次 LLM 生成正式报告。
+            _preliminary = result.content if hasattr(result, 'content') else ""
+            _preliminary_len = len(str(_preliminary).strip())
+            if current_tool_calls == 0 or _preliminary_len < 200:
+                logger.warning(f"[新闻分析师] ⚠️ 未获得可用报告（工具调用数={current_tool_calls}, 正文={_preliminary_len}字符），启动补救机制...")
                 logger.warning(f"[新闻分析师] 📄 LLM原始响应内容 (前500字符): {result.content[:500] if hasattr(result, 'content') else 'No content'}")
 
                 try:
@@ -390,7 +397,7 @@ def create_news_analyst(llm, toolkit):
                     logger.error(f"[新闻分析师] 📋 异常堆栈: {traceback.format_exc()}")
                     report = result.content if hasattr(result, 'content') else ""
             else:
-                # 有工具调用，直接使用结果
+                # 有工具调用且正文足够长（模型已自行给出完整报告），直接使用
                 report = result.content
         
         total_time_taken = (datetime.now() - start_time).total_seconds()

--- a/tradingagents/tools/unified_news_tool.py
+++ b/tradingagents/tools/unified_news_tool.py
@@ -442,13 +442,35 @@ class UnifiedNewsAnalyzer:
         except Exception as e:
             logger.warning(f"[统一新闻工具] Google美股新闻获取失败: {e}")
         
-        # 优先级3: FinnHub新闻（如果可用）
+        # 优先级3: 实时新闻聚合器（FinnHub / Alpha Vantage / NewsAPI 的真实 API 调用）
+        # 🔧 补丁：港股分支（_get_hk_share_news）早就把 get_realtime_stock_news 作为兜底，
+        # 唯独美股分支漏了，导致前两条链一断就直接返回失败。这里补齐，位置放在下面那个
+        # FinnHub 分支之前——因为 toolkit.get_finnhub_news 最终走 interface.get_finnhub_news，
+        # 读的是本地离线目录 news_data 而不是 API，配了 Key 也取不到数据。
+        try:
+            if hasattr(self.toolkit, 'get_realtime_stock_news'):
+                logger.info(f"[统一新闻工具] 尝试实时美股新闻...")
+                result = self.toolkit.get_realtime_stock_news.invoke({"ticker": stock_code, "curr_date": curr_date})
+                # ⚠️ 必须排除失败占位文本：聚合器取不到新闻时会返回一段 160+ 字符的
+                # 「实时新闻获取失败 - XXX / ❌ 错误信息: ...」，长度轻松越过阈值，
+                # 只判长度会把失败提示当成新闻正文写进报告。
+                if (result and len(result.strip()) > 100
+                        and "❌" not in result and "实时新闻获取失败" not in result):
+                    logger.info(f"[统一新闻工具] ✅ 实时美股新闻获取成功: {len(result)} 字符")
+                    return self._format_news_result(result, "实时美股新闻", model_info)
+        except Exception as e:
+            logger.warning(f"[统一新闻工具] 实时美股新闻获取失败: {e}")
+
+        # 优先级4: FinnHub新闻（如果可用）
+        # ⚠️ 故意不修它传错的参数名（{symbol,max_results} vs 签名 {ticker,start_date,end_date}）：
+        # 修好之后它会去读不存在的本地目录并返回一段 >50 字符的中文错误提示，
+        # 而上面的 len>50 判断会把这段错误当成新闻正文采纳，比现在直接抛异常更糟。
         try:
             if hasattr(self.toolkit, 'get_finnhub_news'):
                 logger.info(f"[统一新闻工具] 尝试FinnHub美股新闻...")
                 # 使用LangChain工具的正确调用方式：.invoke()方法和字典参数
                 result = self.toolkit.get_finnhub_news.invoke({"symbol": stock_code, "max_results": min(max_news, 50)})
-                if result and len(result.strip()) > 50:
+                if result and len(result.strip()) > 50 and "❌" not in result and "⚠️" not in result:
                     logger.info(f"[统一新闻工具] ✅ FinnHub美股新闻获取成功: {len(result)} 字符")
                     return self._format_news_result(result, "FinnHub美股新闻", model_info)
         except Exception as e:


### PR DESCRIPTION
## 📋 PR 类型

- [x] 🐛 Bug 修复 (bugfix)

## 📖 PR 描述

### 变更摘要

四个在生产部署中实测发现的缺陷。共同点是**都不会抛错**，而是让整轮分析带着错误或空白的数据以 `success` 状态返回，因此在日志里不易察觉。

不涉及 LLM 适配器，故跳过适配器检查清单。

### 变更详情

**1. `app/services/simple_analysis_service.py` — 只传 `symbol` 的客户端会让整轮分析跑在「股票 None」上**

`request.stock_code` 是 schema 中标注「已废弃，请用 symbol」的字段。只传 `symbol` 的客户端会让 `propagate()` 收到的 ticker 为 `None`，分析全程在 `None` 上执行且最终仍标记成功；结果字典里的 `stock_code` / `stock_symbol` 同样为 `None`，随后在 `app/routers/analysis.py:647-648` 被 `safe_string` 兜底成 `"UNKNOWN"`。

改用本文件 771/847 行已经在用的兼容取值 `request.get_symbol()`。

**2. `app/services/unified_stock_service.py` — 股票搜索只要命中结果就 500**

该处 `collection.find(filter_query)` 漏了 `{"_id": 0}` 投影，返回的 doc 带 `ObjectId`，FastAPI 序列化直接抛：

```
Unable to serialize unknown type: <class 'bson.objectid.ObjectId'>
```

因此 `GET /api/markets/{market}/stocks/search` 一旦命中结果就 500，**空结果反而正常返回**。本文件其余 6 处 `find` / `find_one` 都带了该投影，只有这里漏掉。

**3. `tradingagents/agents/analysts/news_analyst.py` — 开场白被当成最终新闻报告**

模型「正常发起工具调用」时，`result.content` 往往只是「我将立即获取…」这类开场白。而本节点最终返回的是**不含 `tool_calls` 的 `clean_message`**，那些工具调用不会被任何地方执行。原逻辑只在 `current_tool_calls == 0` 时才启动补救，于是这条路径直接把开场白当成最终报告并标记成功。

把判据从「有没有调用工具」改成「有没有拿到可用报告」（正文长度 < 200 字符也视为未获得），两种情况统一走下面**已有且已验证**的补救路径（主动调统一新闻工具 + 二次 LLM 生成正式报告）。模型自行给出完整报告时行为不变。

**4. `tradingagents/tools/unified_news_tool.py` — 美股新闻缺兜底，且失败提示会被当成新闻正文**

- 港股分支（`_get_hk_share_news`）早已把 `get_realtime_stock_news` 作为兜底，**美股分支漏了**，导致前两条链一断就直接返回失败。这里补齐，并放在 FinnHub 分支**之前**——因为 `toolkit.get_finnhub_news` 最终走 `interface.get_finnhub_news`，读的是本地离线目录 `news_data` 而非 API，配了 Key 也取不到数据。
- 补齐时必须排除聚合器的失败占位文本：取不到新闻时它会返回一段 160+ 字符的「实时新闻获取失败 - XXX / ❌ 错误信息: ...」，长度轻松越过阈值，只判长度会把失败提示当成新闻正文写进报告。FinnHub 分支的 `len > 50` 判断有同样问题，一并加上 `❌` / `⚠️` 排除。

> 关于 FinnHub 分支传错的参数名（`{symbol, max_results}` vs 签名 `{ticker, start_date, end_date}`）：**本 PR 故意不修**。修好之后它会去读不存在的本地目录并返回一段 >50 字符的中文错误提示，反而更容易被上面的长度判断当成正文采纳，比现在直接抛异常更糟。要修需要连同数据源一起改，超出本 PR 范围。

### 相关 Issue

无。

## 🧪 测试说明

### 如何测试此 PR

1. **缺陷 2（最容易复现）**：对任一已导入股票数据的 market 调用 `GET /api/markets/{market}/stocks/search?keyword=<能命中的关键词>`。修复前返回 500，修复后正常返回列表；关键词故意写成命中不到的值时，修复前后都正常。
2. **缺陷 1**：调用创建分析的接口时**只传 `symbol`、不传 `stock_code`**，检查任务日志中的 ticker 与返回结果里的 `stock_code`。修复前为 `None` / `"UNKNOWN"`，修复后为实际代码。
3. **缺陷 3**：对一支美股发起含新闻分析师的分析，检查 `news_report` 长度。修复前在模型发起工具调用的路径上恒为 30 字符左右的开场白。
4. **缺陷 4**：在前两条新闻链不可用（未配 key 或网络不通）的情况下分析美股，观察是否会走到实时新闻聚合器，以及失败时报告里是否混入「实时新闻获取失败」字样。

### 测试环境

- [x] Docker 环境

### 破坏性变更

- [x] 此 PR 不包含破坏性变更

四处改动都是在原有分支上收紧判据或补齐兜底，不改任何对外接口与返回结构。

## 📊 影响范围

- [x] 核心交易逻辑
- [x] Web 界面
- [x] 数据获取

## ✅ 检查清单

### 代码质量
- [x] 代码遵循项目的编码规范
- [x] 没有不必要的调试代码或注释
- [x] 变量和函数命名清晰明确
- [x] 代码复用性良好，避免重复代码

### 测试覆盖
- [ ] 新功能有相应的测试用例
- [ ] 所有测试通过
- [x] 手动测试已完成
- [x] 边界情况已考虑

> 说明：四个缺陷的**症状**均在实际部署环境中观察到并按上面「如何测试」逐条复核；本 PR **未新增自动化测试用例，也未运行仓库测试套件**，请维护者按需要求补充。

### 安全考虑
- [x] 没有硬编码的密钥或敏感信息
- [x] 输入验证充分
- [x] 错误处理不泄露敏感信息
- [x] 第三方依赖安全可靠

### 性能考虑
- [x] 新功能不会显著影响性能
- [x] 内存使用合理
- [x] 网络请求优化
- [x] 数据库查询优化（如果适用）

> 缺陷 4 补上的实时新闻兜底只在前两条链都失败时才触发，稳态下不增加出站请求。

## 🏷️ 标签建议

- [x] `bug` - Bug 修复

## 📝 额外说明

四处改动相互独立，如果维护者希望拆成多个 PR 分别审阅，我可以拆开重提。
