### PR TITLE
fix: 修复安全漏洞与数据管道关键缺陷

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -630,6 +630,10 @@ app.add_middleware(
 # 操作日志中间件
 app.add_middleware(OperationLogMiddleware)
 
+# 速率限制中间件（登录防爆破等；Redis 不可用时自动放行）
+from app.middleware.rate_limit import RateLimitMiddleware
+app.add_middleware(RateLimitMiddleware)
+
 
 # 请求日志中间件
 @app.middleware("http")

--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -7,7 +7,7 @@ from fastapi import Request, Response, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 import logging
 from typing import Callable, Dict, Optional
-from core.redis_client import get_redis_service, RedisKeys
+from app.core.redis_client import get_redis_service, RedisKeys
 
 logger = logging.getLogger(__name__)
 

--- a/app/routers/logs.py
+++ b/app/routers/logs.py
@@ -210,11 +210,15 @@ async def delete_log_file(
         logger.warning(f"🗑️ 用户 {current_user['username']} 删除日志文件: {filename}")
         
         service = get_log_export_service()
-        file_path = service.log_dir / filename
-        
+        # 安全检查：先做路径穿越校验，再检查后缀，防止删除日志目录之外的文件
+        try:
+            file_path = service._resolve_safe_path(filename)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="非法的日志文件名")
+
         if not file_path.exists():
             raise HTTPException(status_code=404, detail="日志文件不存在")
-        
+
         # 安全检查：只允许删除 .log 文件
         if not filename.endswith('.log') and not '.log.' in filename:
             raise HTTPException(status_code=400, detail="只能删除日志文件")

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -31,7 +31,6 @@ class AuthService:
         try:
             logger.debug(f"🔍 开始验证token")
             logger.debug(f"📝 Token长度: {len(token)}")
-            logger.debug(f"🔑 JWT密钥: {settings.JWT_SECRET[:10]}...")
             logger.debug(f"🔧 JWT算法: {settings.JWT_ALGORITHM}")
 
             payload = jwt.decode(token, settings.JWT_SECRET, algorithms=[settings.JWT_ALGORITHM])

--- a/app/services/log_export_service.py
+++ b/app/services/log_export_service.py
@@ -125,6 +125,21 @@ class LogExportService:
         else:
             return "other"
 
+    def _resolve_safe_path(self, filename: str) -> Path:
+        """
+        将文件名解析为日志目录内的安全路径，防止路径穿越（如 ../../etc/passwd）
+
+        Returns:
+            解析后的路径
+
+        Raises:
+            ValueError: 文件名试图逃逸日志目录
+        """
+        file_path = (self.log_dir / filename).resolve()
+        if not file_path.is_relative_to(self.log_dir.resolve()):
+            raise ValueError(f"非法的日志文件名: {filename}")
+        return file_path
+
     def read_log_file(
         self,
         filename: str,
@@ -148,8 +163,8 @@ class LogExportService:
         Returns:
             日志内容和统计信息
         """
-        file_path = self.log_dir / filename
-        
+        file_path = self._resolve_safe_path(filename)
+
         if not file_path.exists():
             raise FileNotFoundError(f"日志文件不存在: {filename}")
         
@@ -238,7 +253,8 @@ class LogExportService:
         try:
             # 确定要导出的文件
             if filenames:
-                files_to_export = [self.log_dir / f for f in filenames if (self.log_dir / f).exists()]
+                files_to_export = [self._resolve_safe_path(f) for f in filenames]
+                files_to_export = [f for f in files_to_export if f.exists()]
             else:
                 files_to_export = list(self.log_dir.glob("*.log*"))
             

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -135,14 +135,7 @@ class UserService:
 
             logger.info(f"🔍 [authenticate_user] 用户信息: username={user_doc.get('username')}, email={user_doc.get('email')}, is_active={user_doc.get('is_active')}")
 
-            # 验证密码
-            input_password_hash = self.hash_password(password)
-            stored_password_hash = user_doc["hashed_password"]
-            logger.info(f"🔍 [authenticate_user] 密码哈希对比:")
-            logger.info(f"   输入密码哈希: {input_password_hash[:20]}...")
-            logger.info(f"   存储密码哈希: {stored_password_hash[:20]}...")
-            logger.info(f"   哈希匹配: {input_password_hash == stored_password_hash}")
-
+            # 验证密码（不在日志中输出任何密码哈希片段）
             if not self.verify_password(password, user_doc["hashed_password"]):
                 logger.warning(f"❌ [authenticate_user] 密码错误: {username}")
                 return None
@@ -340,7 +333,6 @@ class UserService:
             admin_doc["_id"] = result.inserted_id
             
             logger.info(f"✅ 管理员用户创建成功: {username}")
-            logger.info(f"   密码: {password}")
             logger.info("   ⚠️  请立即修改默认密码！")
             
             return User(**admin_doc)

--- a/main.py
+++ b/main.py
@@ -1,26 +1,11 @@
-from tradingagents.graph.trading_graph import TradingAgentsGraph
-from tradingagents.default_config import DEFAULT_CONFIG
+"""
+TradingAgents-CN 演示入口（根目录快捷方式）
 
-# 导入日志模块
-from tradingagents.utils.logging_manager import get_logger
-logger = get_logger('default')
+实际实现在 tradingagents/demo.py；也可以使用 CLI 获得交互式体验：
+    python -m cli.main analyze
+"""
 
+from tradingagents.demo import main
 
-# Create a custom config
-config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "google"  # Use a different model
-config["backend_url"] = "https://generativelanguage.googleapis.com/v1beta"  # Use a different backend
-config["deep_think_llm"] = "gemini-2.0-flash"  # Use a different model
-config["quick_think_llm"] = "gemini-2.0-flash"  # Use a different model
-config["max_debate_rounds"] = 1  # Increase debate rounds
-config["online_tools"] = True  # Increase debate rounds
-
-# Initialize with custom config
-ta = TradingAgentsGraph(debug=True, config=config)
-
-# forward propagate
-_, decision = ta.propagate("NVDA", "2024-05-10")
-print(decision)
-
-# Memorize mistakes and reflect
-# ta.reflect_and_remember(1000) # parameter is the position returns
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,13 +85,14 @@ dependencies = [
     "toml>=0.10.2",
     "tqdm>=4.67.1",
     "typing-extensions>=4.14.0",
+    "typer>=0.12.0",  # cli/ 命令行入口依赖
 ]
 
 [project.optional-dependencies]
 qianfan = ["qianfan>=0.4.20"]
 
 [project.scripts]
-tradingagents = "main:main"
+tradingagents = "tradingagents.demo:main"
 
 [tool.setuptools.packages.find]
 include = ["tradingagents*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ aiofiles>=0.8.0  # 异步文件操作
 httpx>=0.24.0  # 异步HTTP客户端
 sse-starlette>=1.0.0  # Server-Sent Events支持
 concurrent-log-handler>=0.9.24  # Windows 友好的日志轮转处理器
+typer>=0.12.0  # CLI命令行框架，cli/ 依赖

--- a/scripts/补充行业信息_akshare.py
+++ b/scripts/补充行业信息_akshare.py
@@ -78,7 +78,7 @@ async def get_stock_industry_from_akshare(code: str) -> Dict[str, str]:
         return {"industry": "未知", "area": "未知"}
 
 
-async def补充行业信息(
+async def 补充行业信息(
     limit: int = None,
     batch_size: int = 50,
     delay: float = 0.5

--- a/tradingagents/dataflows/data_source_manager.py
+++ b/tradingagents/dataflows/data_source_manager.py
@@ -282,7 +282,7 @@ class DataSourceManager:
             duration = time.time() - start_time
             result_length = len(result) if result else 0
 
-            if result and "❌" not in result:
+            if result and "❌" not in result and "⚠️" not in result:
                 logger.info(f"✅ [数据来源: {self.current_source.value}] 成功获取基本面数据: {symbol} ({result_length}字符, 耗时{duration:.2f}秒)",
                            extra={
                                'symbol': symbol,
@@ -661,22 +661,23 @@ class DataSourceManager:
 
     def _get_volume_safely(self, data: pd.DataFrame) -> float:
         """
-        安全获取成交量数据
+        安全获取区间平均成交量数据
 
         Args:
             data: 股票数据DataFrame
 
         Returns:
-            float: 成交量，如果获取失败返回0
+            float: 区间平均成交量，如果获取失败返回0
         """
         try:
-            if 'volume' in data.columns:
-                return data['volume'].iloc[-1]
-            elif 'vol' in data.columns:
-                return data['vol'].iloc[-1]
-            else:
-                return 0
-        except Exception:
+            volume_columns = ['volume', 'vol', 'turnover', 'trade_volume']
+            for col in volume_columns:
+                if col in data.columns:
+                    return data[col].mean()
+            logger.warning(f"⚠️ 未找到成交量列，可用列: {list(data.columns)}")
+            return 0
+        except Exception as e:
+            logger.error(f"❌ 获取成交量失败: {e}")
             return 0
 
     def _format_stock_data_response(self, data: pd.DataFrame, symbol: str, stock_name: str,
@@ -1118,9 +1119,10 @@ class DataSourceManager:
                               })
 
                 # 数据质量异常时也尝试降级到其他数据源
-                fallback_result = self._try_fallback_sources(symbol, start_date, end_date)
+                # _try_fallback_sources 返回 (结果字符串, 数据源名称) 元组，需先解包再判断
+                fallback_result, fallback_source = self._try_fallback_sources(symbol, start_date, end_date)
                 if fallback_result and "❌" not in fallback_result and "错误" not in fallback_result:
-                    logger.info(f"✅ [数据来源: 备用数据源] 降级成功获取数据: {symbol}")
+                    logger.info(f"✅ [数据来源: 备用数据源({fallback_source})] 降级成功获取数据: {symbol}")
                     return fallback_result
                 else:
                     logger.error(f"❌ [数据来源: 所有数据源失败] 所有数据源都无法获取有效数据: {symbol}")
@@ -1138,7 +1140,8 @@ class DataSourceManager:
                             'error': str(e),
                             'event_type': 'data_fetch_exception'
                         }, exc_info=True)
-            return self._try_fallback_sources(symbol, start_date, end_date)
+            fallback_result, _ = self._try_fallback_sources(symbol, start_date, end_date)
+            return fallback_result
 
     def _get_mongodb_data(self, symbol: str, start_date: str, end_date: str, period: str = "daily") -> tuple[str, str | None]:
         """
@@ -1360,25 +1363,6 @@ class DataSourceManager:
     #     logger.error(f"❌ TDX数据源已不再支持")
     #     return f"❌ TDX数据源已不再支持"
 
-    def _get_volume_safely(self, data) -> float:
-        """安全地获取成交量数据，支持多种列名"""
-        try:
-            # 支持多种可能的成交量列名
-            volume_columns = ['volume', 'vol', 'turnover', 'trade_volume']
-
-            for col in volume_columns:
-                if col in data.columns:
-                    logger.info(f"✅ 找到成交量列: {col}")
-                    return data[col].sum()
-
-            # 如果都没找到，记录警告并返回0
-            logger.warning(f"⚠️ 未找到成交量列，可用列: {list(data.columns)}")
-            return 0
-
-        except Exception as e:
-            logger.error(f"❌ 获取成交量失败: {e}")
-            return 0
-
     def _try_fallback_sources(self, symbol: str, start_date: str, end_date: str, period: str = "daily") -> tuple[str, str | None]:
         """
         尝试备用数据源 - 避免递归调用
@@ -1550,7 +1534,7 @@ class DataSourceManager:
                 from tradingagents.config.database_manager import get_database_manager
                 db_manager = get_database_manager()
                 if db_manager and db_manager.is_mongodb_available():
-                    collection = db_manager.mongodb_db['stock_basic_info']
+                    collection = db_manager.get_mongodb_db()['stock_basic_info']
                     stocks = list(collection.find({}, {'_id': 0}))
                     if stocks:
                         logger.info(f"✅ 从MongoDB获取所有股票: {len(stocks)}条")
@@ -1854,15 +1838,12 @@ class DataSourceManager:
     def _get_valuation_indicators(self, symbol: str) -> Dict:
         """从stock_basic_info集合获取估值指标"""
         try:
+            from tradingagents.config.database_manager import get_database_manager
             db_manager = get_database_manager()
             if not db_manager.is_mongodb_available():
                 return {}
-                
-            client = db_manager.get_mongodb_client()
-            db = client[db_manager.config.mongodb_config.database_name]
-            
-            # 从stock_basic_info集合获取估值指标
-            collection = db['stock_basic_info']
+
+            collection = db_manager.get_mongodb_db()['stock_basic_info']
             result = collection.find_one({'ts_code': symbol})
             
             if result:
@@ -2036,7 +2017,7 @@ class DataSourceManager:
                     else:
                         continue
 
-                    if result and "❌" not in result:
+                    if result and "❌" not in result and "⚠️" not in result:
                         logger.info(f"✅ [数据来源: 备用数据源] 降级成功获取基本面: {source.value}")
                         return result
                     else:

--- a/tradingagents/dataflows/providers/china/tushare.py
+++ b/tradingagents/dataflows/providers/china/tushare.py
@@ -1243,10 +1243,10 @@ class TushareProvider(BaseStockDataProvider):
             "pct_chg": self._convert_to_float(raw_data.get('pct_chg')),
 
             # 成交数据
-            # 🔥 成交量单位转换：Tushare 返回的是手，需要转换为股
-            "volume": self._convert_to_float(raw_data.get('vol')) * 100 if raw_data.get('vol') else None,
+            # 🔥 成交量单位转换：Tushare 返回的是手，需要转换为股（停牌时 vol/amount 为 0，应保留 0 而非 None）
+            "volume": self._convert_to_float(raw_data.get('vol')) * 100 if raw_data.get('vol') is not None else None,
             # 🔥 成交额单位转换：Tushare daily 接口返回的是千元，需要转换为元
-            "amount": self._convert_to_float(raw_data.get('amount')) * 1000 if raw_data.get('amount') else None,
+            "amount": self._convert_to_float(raw_data.get('amount')) * 1000 if raw_data.get('amount') is not None else None,
 
             # 财务指标
             "total_mv": self._convert_to_float(raw_data.get('total_mv')),
@@ -1276,6 +1276,8 @@ class TushareProvider(BaseStockDataProvider):
         if symbol.isdigit() and len(symbol) == 6:
             if symbol.startswith(('60', '68', '90')):
                 return f"{symbol}.SH"  # 上交所
+            elif symbol.startswith(('43', '83', '87', '92', '88')):
+                return f"{symbol}.BJ"  # 北交所
             else:
                 return f"{symbol}.SZ"  # 深交所
 

--- a/tradingagents/dataflows/stock_api.py
+++ b/tradingagents/dataflows/stock_api.py
@@ -86,12 +86,20 @@ def search_stocks_by_name(name: str) -> List[Dict[str, Any]]:
         >>> for stock in results:
         logger.info(f"{stock['code']}: {stock['name']}")
     """
-    # 这个功能需要MongoDB支持，暂时通过原有方式实现
+    # 从股票基础信息列表中按名称模糊匹配
     try:
-        from ..examples.stock_query_examples import EnhancedStockQueryService
+        from tradingagents.dataflows.data_source_manager import get_data_source_manager
 
-        service = EnhancedStockQueryService()
-        return service.query_stocks_by_name(name)
+        manager = get_data_source_manager()
+        all_stocks = manager.get_stock_basic_info()
+        if isinstance(all_stocks, list) and all_stocks:
+            name_lower = name.lower()
+            matches = [
+                stock for stock in all_stocks
+                if name_lower in str(stock.get('name', '')).lower()
+            ]
+            return matches[:20]
+        return [{'error': '股票基础信息不可用，无法按名称搜索'}]
     except Exception as e:
         return [{'error': f'名称搜索功能不可用: {str(e)}'}]
 
@@ -109,13 +117,15 @@ def check_data_sources() -> Dict[str, Any]:
     """
     service = get_stock_data_service()
     
+    mongodb_ok = service.db_manager is not None and service.db_manager.is_mongodb_available()
+
     return {
-        'mongodb_available': service.db_manager is not None and service.db_manager.mongodb_db is not None,
+        'mongodb_available': mongodb_ok,
         'unified_api_available': True,  # 统一接口总是可用
         'enhanced_fetcher_available': True,  # 这个通常都可用
-        'fallback_mode': service.db_manager is None or service.db_manager.mongodb_db is None,
+        'fallback_mode': not mongodb_ok,
         'recommendation': (
-            "所有数据源正常" if service.db_manager and service.db_manager.mongodb_db 
+            "所有数据源正常" if mongodb_ok
             else "建议配置MongoDB以获得最佳性能，当前使用统一数据接口降级模式"
         )
     }

--- a/tradingagents/dataflows/stock_data_service.py
+++ b/tradingagents/dataflows/stock_data_service.py
@@ -183,11 +183,11 @@ class StockDataService:
     
     def _cache_to_mongodb(self, data: Any) -> bool:
         """将数据缓存到MongoDB"""
-        if not self.db_manager or not self.db_manager.mongodb_db:
+        if not self.db_manager or not self.db_manager.is_mongodb_available():
             return False
-        
+
         try:
-            collection = self.db_manager.mongodb_db['stock_basic_info']
+            collection = self.db_manager.get_mongodb_db()['stock_basic_info']
             
             if isinstance(data, list):
                 # 批量插入

--- a/tradingagents/demo.py
+++ b/tradingagents/demo.py
@@ -1,0 +1,34 @@
+"""
+TradingAgents-CN 演示入口
+
+运行一次完整的单股多智能体分析示例（原版 TradingAgents 的演示脚本）。
+安装后可通过 `tradingagents` 命令运行，或 `python main.py`。
+"""
+
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+
+def main():
+    # Create a custom config
+    config = DEFAULT_CONFIG.copy()
+    config["llm_provider"] = "google"  # Use a different model
+    config["backend_url"] = "https://generativelanguage.googleapis.com/v1beta"  # Use a different backend
+    config["deep_think_llm"] = "gemini-2.0-flash"  # Use a different model
+    config["quick_think_llm"] = "gemini-2.0-flash"  # Use a different model
+    config["max_debate_rounds"] = 1  # Increase debate rounds
+    config["online_tools"] = True  # Increase debate rounds
+
+    # Initialize with custom config
+    ta = TradingAgentsGraph(debug=True, config=config)
+
+    # forward propagate
+    _, decision = ta.propagate("NVDA", "2024-05-10")
+    print(decision)
+
+    # Memorize mistakes and reflect
+    # ta.reflect_and_remember(1000) # parameter is the position returns
+
+
+if __name__ == "__main__":
+    main()

--- a/tradingagents/llm_adapters/google_openai_adapter.py
+++ b/tradingagents/llm_adapters/google_openai_adapter.py
@@ -74,7 +74,7 @@ class ChatGoogleOpenAI(ChatGoogleGenerativeAI):
 
             # 验证环境变量中的 API Key 是否有效（排除占位符）
             if env_api_key and is_valid_api_key(env_api_key):
-                logger.info(f"✅ [Google初始化] 环境变量中的 API Key 有效，长度: {len(env_api_key)}, 前10位: {env_api_key[:10]}...")
+                logger.info(f"✅ [Google初始化] 环境变量中的 API Key 有效，长度: {len(env_api_key)}")
                 google_api_key = env_api_key
             elif env_api_key:
                 logger.warning("⚠️ [Google初始化] 环境变量中的 API Key 无效（可能是占位符），将被忽略")

--- a/tradingagents/llm_adapters/openai_compatible_base.py
+++ b/tradingagents/llm_adapters/openai_compatible_base.py
@@ -93,7 +93,7 @@ class OpenAICompatibleBase(ChatOpenAI):
 
             # 验证环境变量中的 API Key 是否有效（排除占位符）
             if env_api_key and is_valid_api_key(env_api_key):
-                logger.info(f"✅ [{provider_name}初始化] 环境变量中的 API Key 有效，长度: {len(env_api_key)}, 前10位: {env_api_key[:10]}...")
+                logger.info(f"✅ [{provider_name}初始化] 环境变量中的 API Key 有效，长度: {len(env_api_key)}")
                 api_key = env_api_key
             elif env_api_key:
                 logger.warning(f"⚠️ [{provider_name}初始化] 环境变量中的 API Key 无效（可能是占位符），将被忽略")

--- a/web/utils/auth_manager.py
+++ b/web/utils/auth_manager.py
@@ -28,7 +28,8 @@ class AuthManager:
     
     def __init__(self):
         self.users_file = Path(__file__).parent.parent / "config" / "users.json"
-        self.session_timeout = 600000  
+        # 会话超时（秒），与 time.time() 的秒级时间戳比较；10分钟无操作自动失效
+        self.session_timeout = 600
         self._ensure_users_file()
     
     def _ensure_users_file(self):
@@ -275,7 +276,7 @@ class AuthManager:
             <script>
             console.log('🔐 保存认证数据到localStorage');
             try {{
-                const authData = {json.dumps(auth_data)};
+                const authData = {json.dumps(auth_data).replace('</', '<\\/')};
                 localStorage.setItem('tradingagents_auth', JSON.stringify(authData));
                 console.log('✅ 认证数据已保存到localStorage:', authData);
             }} catch (e) {{
@@ -343,14 +344,23 @@ class AuthManager:
             if username not in users:
                 logger.warning(f"⚠️ 尝试恢复不存在的用户: {username}")
                 return False
-            
+
+            # 安全修复：role/permissions 一律以服务端 users.json 为准，
+            # 不采信客户端（URL 参数/localStorage）传入的值，防止伪造管理员身份
+            stored_user = users[username]
+            safe_user_info = {
+                "username": username,
+                "role": stored_user.get("role", "user"),
+                "permissions": stored_user.get("permissions", [])
+            }
+
             # 恢复登录状态，使用原始登录时间或当前时间
             restore_time = login_time if login_time is not None else time.time()
-            
+
             st.session_state.authenticated = True
-            st.session_state.user_info = user_info
+            st.session_state.user_info = safe_user_info
             st.session_state.login_time = restore_time
-            
+
             logger.info(f"✅ 从前端缓存恢复用户 {username} 的登录状态")
             logger.debug(f"🔍 [恢复状态] login_time: {restore_time}, current_time: {time.time()}")
             return True


### PR DESCRIPTION
## 概述

本 PR 修复了代码审查中发现的高优先级安全漏洞与数据管道缺陷，共 18 个文件。每项修复都经过验证（AST 语法检查、模块导入测试、路径穿越/北交所代码映射的单元验证、tests/config + tests/dataflows 测试套件）。

## 安全修复

| # | 问题 | 位置 | 修复 |
|---|------|------|------|
| 1 | **URL 参数伪造任意用户登录态**：`?restore_auth=<base64>` 解码后的 role/permissions 被原样采信，任何人可伪造 admin 会话（无密码、无签名） | `web/app.py:445` + `web/utils/auth_manager.py` `restore_from_cache` | role/permissions 一律以服务端 users.json 为准，不采信客户端传入值 |
| 2 | **会话超时单位错误**：`session_timeout=600000`（毫秒写法）与 `time.time()`（秒）比较，实际 6.9 天才过期，与"10分钟"注释矛盾 | `web/utils/auth_manager.py:31` | 改为 600 秒 |
| 3 | **登录缓存 JS 注入**：`json.dumps(auth_data)` 直接嵌入 `<script>`，username 含 `</script>` 即逃逸 | `web/utils/auth_manager.py` | 对 `</` 转义 |
| 4 | **日志接口路径穿越**：读取/导出/删除均未校验路径边界，`filename=../../xxx.log` 可越界读/删任意文件 | `app/services/log_export_service.py` + `app/routers/logs.py` | 新增 `_resolve_safe_path()`（resolve + is_relative_to 校验），三处调用点全部接入 |
| 5 | **限流中间件形同虚设**：定义了登录防爆破规则但从未注册，且 import 包名错误（`core.redis_client`），一注册即 ImportError | `app/middleware/rate_limit.py` + `app/main.py` | 修正为 `app.core.redis_client` 并注册 |
| 6 | **敏感信息进日志**：API Key 前10位（INFO级）、JWT 密钥前缀、密码哈希前缀、创建管理员时的明文密码 | `llm_adapters/*`、`auth_service.py`、`user_service.py` | 全部移除 |

## 数据管道修复

| # | 问题 | 影响 |
|---|------|------|
| 7 | **降级逻辑元组 bug**：`_try_fallback_sources` 返回 `(结果, 数据源)` 元组，调用方 `"❌" not in fallback_result` 对元组只做元素相等比较，**成功与失败检查都恒通过**，元组被当字符串返回给上层 | MongoDB 主源/降级路径命中时整个行情管道拿到 tuple |
| 8 | `_get_valuation_indicators` 调用未导入的 `get_database_manager`（NameError 被 except 吞掉）+ 不存在的属性链 | PE/PB/市值估值指标永远静默缺失 |
| 9 | 引用不存在的 `db_manager.mongodb_db` 属性（实际为 `get_mongodb_db()`） | MongoDB 股票列表缓存整体失效 |
| 10 | 基本面降级判据只认 "❌"，`"⚠️ 功能暂时不可用"` 占位文本被当作有效数据返回 | 不再降级到 AKShare |
| 11 | `_get_volume_safely` 定义两次，生效版本返回区间总和，调用处标注"平均成交量" | 总成交量被当平均值喂给 LLM |
| 12 | 北交所代码（43/83/87/92/88 开头）映射为 `.SZ` | 北交所股票查错交易所 |
| 13 | 停牌时 `vol/amount=0` 被 `if raw_data.get('vol')` 判为 falsy 置 None | 停牌日成交数据丢失 |
| 14 | `search_stocks_by_name` 导入不存在的 `..examples` 模块 | 按名称搜股恒返回 error |

## 工程修复

- `main.py` 模块级代码 import 即执行完整 NVDA 分析且无 `main()` 函数，`pyproject.toml` 的 `tradingagents = "main:main"` console script 必然损坏（且 main.py 不在打包范围）——演示入口移入 `tradingagents/demo.py`，修正入口声明，根目录 main.py 变为薄封装
- 补充 CLI 依赖 `typer`（pyproject + requirements.txt，原先只存在于 requirements-lock.txt）
- 修复 `scripts/补充行业信息_akshare.py` 语法错误（`async def` 与函数名间缺空格，文件无法运行）

## 测试

- ✅ 18 个修改文件全部通过 AST 语法检查
- ✅ 核心模块导入验证（data_source_manager / stock_api / stock_data_service / tushare / demo）
- ✅ 路径穿越防护单元验证：`../../etc/passwd` 被拦截，`app.log` 正常解析
- ✅ 北交所映射验证：`430047→.BJ`、`830799→.BJ`、`600519→.SH`、`000001→.SZ`、`920001→.BJ`
- ✅ `pytest tests/config tests/dataflows`：8 通过；3 个失败为**预先存在**（已用 git stash 在 main 上复验，是 MockDB 缺 `market_quotes` 属性的旧问题，与本 PR 无关）

## 范围外（建议后续处理）

审查中还发现但本 PR 未覆盖的重项：
- `app/routers/` 大量端点无鉴权/无属主校验（IDOR）：sync、multi_period_sync、analysis 任务读写、reports 等
- docker-compose/JWT 密钥默认值体系（`change-me-in-production`、`tradingagents123`）
- 队列可见性超时不续期导致长任务双跑；`get_database()` 硬编码幽灵库
- `simple_analysis_service.py` 的假进度线程（`simulate_progress` 用 time.sleep 伪造分析阶段）
- tests/ 顶层约 88% 测试无断言；scripts/ 中十余处硬编码数据库凭据