### PR TITLE
deps: bump chainlit to 2.12.0

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -42,7 +42,7 @@ cachetools==5.5.2
 celery==5.5.3
 certifi==2025.8.3
 cffi==2.0.0
-chainlit==2.8.0
+chainlit==2.12.0
 charset-normalizer==3.4.3
 chevron==0.14.0
 chromadb==1.1.0


### PR DESCRIPTION
Updates `chainlit` to address GHSA-w3fx-mc44-mf6j, GHSA-hvfh-5mj3-5f3j, GHSA-2g59-m95p-pgfq, GHSA-v492-6xx2-p57g, PYSEC-2026-1237, PYSEC-2026-1238, PYSEC-2026-598.

Evidence:
- `requirements-lock.txt` referenced `chainlit@2.8.0`
- osv-scanner reported the advisories above for `chainlit@2.8.0`
- updated version: `2.12.0`

Validation:
- osv-scanner no longer reports any chainlit advisories after the update
- `pip install chainlit==2.12.0` succeeds in a clean venv (Python 3.11)

Scope: dependency/lockfile update only.
