### PR TITLE
feat: enhance MongoDB connection handling and configuration loading

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -7,6 +7,18 @@ import re
 import getpass
 from pathlib import Path
 
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_ENV_FILE = _PROJECT_ROOT / ".env"
+
+# 始终从项目根目录加载 .env，避免从 app/ 目录启动时读不到配置
+if _ENV_FILE.exists():
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(_ENV_FILE, override=False)
+    except ImportError:
+        pass
+
 # Legacy env var aliases (deprecated): map API_HOST/PORT/DEBUG -> HOST/PORT/DEBUG
 _LEGACY_ENV_ALIASES = {
     "API_HOST": "HOST",
@@ -331,7 +343,11 @@ class Settings(BaseSettings):
         return not self.DEBUG
 
     # Ignore any extra environment variables present in .env or process env
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=str(_ENV_FILE) if _ENV_FILE.exists() else ".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
 
 settings = Settings()
 

--- a/app/services/operation_log_service.py
+++ b/app/services/operation_log_service.py
@@ -66,7 +66,7 @@ class OperationLogService:
             
         except Exception as e:
             logger.error(f"创建操作日志失败: {e}")
-            raise Exception(f"创建操作日志失败: {str(e)}")
+            return ""
     
     async def get_logs(self, query: OperationLogQuery) -> Tuple[List[OperationLogResponse], int]:
         """获取操作日志列表"""

--- a/scripts/import_config_and_create_user.py
+++ b/scripts/import_config_and_create_user.py
@@ -21,6 +21,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional
+from urllib.parse import quote_plus, urlparse
 import argparse
 
 # 添加项目根目录到路径
@@ -281,6 +282,36 @@ def load_export_file(file_path: str) -> Dict[str, Any]:
         sys.exit(1)
 
 
+def _mask_mongo_uri(uri: str) -> str:
+    """隐藏连接串中的密码"""
+    return re.sub(r"://([^:/]+):([^@]+)@", r"://\1:***@", uri)
+
+
+def _compose_mongo_uri(
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    database: str,
+    auth_source: str,
+) -> str:
+    """用离散字段组装 MongoDB URI（密码做 URL 编码）"""
+    if username and password:
+        return (
+            f"mongodb://{quote_plus(str(username))}:{quote_plus(str(password))}"
+            f"@{host}:{port}/{database}?authSource={auth_source}"
+        )
+    return f"mongodb://{host}:{port}/{database}"
+
+
+def _connection_string_username(uri: str) -> Optional[str]:
+    """从连接串中解析用户名，解析失败时返回 None"""
+    try:
+        return urlparse(uri).username
+    except Exception:
+        return None
+
+
 def connect_mongodb(use_docker: bool = True, config: dict = None) -> MongoClient:
     """连接到 MongoDB
 
@@ -302,27 +333,34 @@ def connect_mongodb(use_docker: bool = True, config: dict = None) -> MongoClient
 
     database = config['mongodb_database']
     auth_source = config.get('mongodb_auth_source') or 'admin'
-    mongo_uri = config.get('mongodb_connection_string')
+    host = 'mongodb' if use_docker else config['mongodb_host']
+    port = config.get('mongodb_port', 27017)
+    username = config.get('mongodb_username') or ''
+    password = config.get('mongodb_password') or ''
+    conn_str = config.get('mongodb_connection_string')
     env_name = "Docker 容器内" if use_docker else "宿主机"
 
-    if not mongo_uri:
-        # 构建 MongoDB URI
-        host = 'mongodb' if use_docker else config['mongodb_host']
-        port = config['mongodb_port']
-        username = config['mongodb_username']
-        password = config['mongodb_password']
-        mongo_uri = f"mongodb://{username}:{password}@{host}:{port}/{database}?authSource={auth_source}"
-        masked_uri = f"mongodb://{username}:***@{host}:{port}/{database}?authSource={auth_source}"
-    else:
-        # 如果是 Docker 模式，并且 .env 写的是 localhost，则替换成容器内服务名
+    # 离散账号优先：.env 里 MONGODB_CONNECTION_STRING 经常和 USERNAME/PASSWORD 不一致
+    if username and password:
+        conn_user = _connection_string_username(conn_str) if conn_str else None
+        if conn_user and conn_user != username:
+            print(
+                f"⚠️  MONGODB_CONNECTION_STRING 用户为 '{conn_user}'，"
+                f"与 MONGODB_USERNAME='{username}' 不一致，已改用离散字段"
+            )
+        mongo_uri = _compose_mongo_uri(host, port, username, password, database, auth_source)
+    elif conn_str:
+        mongo_uri = conn_str
         if use_docker:
             mongo_uri = mongo_uri.replace("@localhost:", "@mongodb:")
             mongo_uri = mongo_uri.replace("//localhost:", "//mongodb:")
-        masked_uri = re.sub(r"://([^:/]+):([^@]+)@", r"://\1:***@", mongo_uri)
+    else:
+        mongo_uri = _compose_mongo_uri(host, port, username, password, database, auth_source)
 
     print(f"\n🔌 连接到 MongoDB ({env_name})...")
-    print(f"   URI: {masked_uri}")
+    print(f"   URI: {_mask_mongo_uri(mongo_uri)}")
     print(f"   数据库: {database}")
+    print(f"   认证: 用户={username or '(无)'}  authSource={auth_source}")
 
     try:
         client = MongoClient(mongo_uri, serverSelectionTimeoutMS=5000)
@@ -339,6 +377,8 @@ def connect_mongodb(use_docker: bool = True, config: dict = None) -> MongoClient
         else:
             print(f"   请确保 MongoDB 正在运行并监听端口 {port}")
             print(f"   检查端口: netstat -an | findstr {port}")
+        print(f"   请核对 .env 中的 MONGODB_USERNAME / MONGODB_PASSWORD / MONGODB_AUTH_SOURCE")
+        print(f"   以及 MONGODB_CONNECTION_STRING 是否与上面三项一致")
         sys.exit(1)
 
 


### PR DESCRIPTION
## 📋 PR 类型

请标记此 PR 的类型：

- [ ] 🌟 新功能 (feature)
- [x] 🐛 Bug 修复 (bugfix)
- [ ] 🧹 代码重构 (refactor)
- [ ] 📝 文档更新 (documentation)
- [ ] 🎨 样式优化 (style)
- [ ] ⚡ 性能优化 (performance)
- [x] 🔧 配置/构建 (config/build)
- [ ] 🧪 测试相关 (test)
- [ ] 🤖 LLM 适配器集成 (llm-adapter)

## 📖 PR 描述

### 变更摘要

修复从非项目根目录启动时读不到 `.env` 的问题，并增强 MongoDB 连接配置的一致性校验、敏感信息脱敏与错误提示，避免因连接串与离散字段不一致导致认证失败。

### 变更详情

- **从项目根目录加载环境变量**：在 `app/core/config.py` 中根据文件位置解析项目根目录，优先加载根目录 `.env`，避免从 `app/` 等子目录启动时配置读取失败；`Settings` 的 `env_file` 同步指向同一绝对路径。
- **MongoDB URI 组装与脱敏**：在 `scripts/import_config_and_create_user.py` 中新增 `_mask_mongo_uri`、`_compose_mongo_uri`、`_connection_string_username`。密码在组装时做 URL 编码，日志输出时隐藏密码。
- **配置一致性与错误处理**：当 `MONGODB_USERNAME` / `MONGODB_PASSWORD` 与 `MONGODB_CONNECTION_STRING` 中的用户不一致时，优先使用离散字段并给出明确警告；连接失败时提示核对用户名、密码、`authSource` 与连接串是否一致。
- **操作日志容错**：`operation_log_service.py` 在创建日志失败时改为返回空字符串，避免日志写入异常中断主流程。

### 相关 Issue

<!-- 无关联 Issue -->

## 🤖 LLM 适配器集成检查清单

> 本 PR 不涉及 LLM 适配器集成，已跳过此部分。

## 🧪 测试说明

### 如何测试此 PR

1. 确认项目根目录存在 `.env`，分别从项目根目录和 `app/` 目录启动服务，确认都能正确读到 `MONGODB_*` 等配置。
2. 在 `.env` 中设置 `MONGODB_USERNAME` / `MONGODB_PASSWORD`，同时保留一条用户名不同的 `MONGODB_CONNECTION_STRING`，运行 `python scripts/import_config_and_create_user.py`，确认输出警告并改用离散字段连接成功。
3. 故意填入错误密码或错误 `authSource`，确认日志中的 URI 已脱敏（密码显示为 `***`），且错误提示指向核对 `.env` 中的用户名、密码、认证库和连接串。
4. 触发一次会写操作日志的接口，在日志写入失败场景下确认主流程不会因异常中断。

### 测试环境

- [x] 本地开发环境
- [ ] Docker 环境
- [ ] 生产环境

### 破坏性变更

- [ ] 此 PR 包含破坏性变更
- [x] 此 PR 不包含破坏性变更

如果包含破坏性变更，请说明：

无。行为变化仅在于：环境变量始终从项目根 `.env` 加载；MongoDB 连接在离散账号存在时优先于完整连接串；操作日志写入失败不再向上抛出异常。

## 📊 影响范围

请标记此 PR 影响的组件：

- [ ] 核心交易逻辑
- [ ] LLM 适配器
- [ ] Web 界面
- [ ] 数据获取
- [x] 配置系统
- [ ] 测试框架
- [ ] 文档
- [x] 部署配置

## 🔗 相关链接

- 相关文档:
- 参考资料:
- 相关 PR:
- 提交: `f77b0708aa3477e4715b55ced01cdb2885eb0f99`

## 📷 截图/演示

不涉及 UI 变更。连接日志示例如下（密码已脱敏）：

```text
🔌 连接到 MongoDB (宿主机)...
   URI: mongodb://user:***@127.0.0.1:27017/tradingagents?authSource=admin
   数据库: tradingagents
   认证: 用户=user  authSource=admin
```

当连接串与离散字段用户不一致时：

```text
⚠️  MONGODB_CONNECTION_STRING 用户为 'olduser'，与 MONGODB_USERNAME='user' 不一致，已改用离散字段
```

## ✅ 检查清单

请确认以下项目：

### 代码质量

- [x] 代码遵循项目的编码规范
- [x] 没有不必要的调试代码或注释
- [x] 变量和函数命名清晰明确
- [x] 代码复用性良好，避免重复代码

### 测试覆盖

- [ ] 新功能有相应的测试用例
- [ ] 所有测试通过
- [x] 手动测试已完成
- [x] 边界情况已考虑

### 文档更新

- [ ] README 已更新（如果需要）
- [ ] API 文档已更新（如果需要）
- [ ] 变更日志已更新（如果需要）
- [ ] 配置文档已更新（如果需要）

### 安全考虑

- [x] 没有硬编码的密钥或敏感信息
- [x] 输入验证充分
- [x] 错误处理不泄露敏感信息
- [x] 第三方依赖安全可靠

### 性能考虑

- [x] 新功能不会显著影响性能
- [x] 内存使用合理
- [x] 网络请求优化
- [x] 数据库查询优化（如果适用）

## 🏷️ 标签建议

请为此 PR 建议适当的标签：

- [x] `enhancement` - 新功能或改进
- [x] `bug` - Bug 修复
- [ ] `documentation` - 文档相关
- [ ] `refactor` - 代码重构
- [ ] `performance` - 性能优化
- [x] `security` - 安全相关
- [ ] `llm-adapter` - LLM 适配器
- [ ] `ui/ux` - 用户界面/体验
- [x] `config` - 配置相关
- [ ] `testing` - 测试相关

## 👥 审查者

建议的审查者：

<!-- 请按仓库维护者名单补充 @mention -->

## 📝 额外说明

- 涉及文件：
  - `app/core/config.py`：固定从项目根加载 `.env`
  - `scripts/import_config_and_create_user.py`：MongoDB URI 组装、脱敏与配置一致性提示
  - `app/services/operation_log_service.py`：写日志失败时不再抛异常
- 本 PR 基于提交 `f77b0708`，不包含破坏性变更。

---

**感谢您的贡献！** 🎉

请确保您已经阅读并遵循了我们的 [贡献指南](../docs/LLM_INTEGRATION_GUIDE.md)。如果您有任何问题，请随时在 PR 中提问或联系维护者。
